### PR TITLE
Generic storage

### DIFF
--- a/examples/matmul.rs
+++ b/examples/matmul.rs
@@ -6,7 +6,7 @@ use ndarray::Array;
 
 fn main()
 {
-    let mat = Array::range(0.0f32, 16.0).reshape((2, 4, 2)).unwrap().to_owned();
+    let mat = Array::range(0.0f32, 16.0).reshape_clone((2, 4, 2));
     println!("{a:?}\n times \n{b:?}\nis equal to:\n{c:?}",
              a=mat.subview(2,1),
              b=mat.subview(0,1),

--- a/examples/matmul.rs
+++ b/examples/matmul.rs
@@ -6,7 +6,7 @@ use ndarray::Array;
 
 fn main()
 {
-    let mat = Array::range(0.0f32, 16.0).reshape((2, 4, 2));
+    let mat = Array::range(0.0f32, 16.0).reshape((2, 4, 2)).unwrap().to_owned();
     println!("{a:?}\n times \n{b:?}\nis equal to:\n{c:?}",
              a=mat.subview(2,1),
              b=mat.subview(0,1),

--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -1,12 +1,14 @@
 use std::fmt;
 use super::{Array, Dimension};
+use std::ops::Deref;
 
 /// HACK: fmt::rt::FlagAlternate has been hidden away
 const FLAG_ALTERNATE: usize = 2;
 
-fn format_array<A, D: Dimension, F>(view: &Array<A, D>, f: &mut fmt::Formatter,
-                                    mut format: F) -> fmt::Result where
-    F: FnMut(&mut fmt::Formatter, &A) -> fmt::Result,
+fn format_array<A, S, D: Dimension, F>(view: &Array<A, S, D>,
+                                       f: &mut fmt::Formatter,
+                                       mut format: F) -> fmt::Result where
+    F: FnMut(&mut fmt::Formatter, &A) -> fmt::Result, S: Deref<Target=[A]>
 {
     let ndim = view.dim.slice().len();
     /* private nowadays
@@ -71,7 +73,8 @@ fn format_array<A, D: Dimension, F>(view: &Array<A, D>, f: &mut fmt::Formatter,
 }
 
 // NOTE: We can impl other fmt traits here
-impl<'a, A: fmt::Display, D: Dimension> fmt::Display for Array<A, D>
+impl<'a, A: fmt::Display, S, D: Dimension> fmt::Display for Array<A, S, D>
+where S: Deref<Target=[A]>
 {
     /// Format the array using `Display` and apply the formatting parameters used
     /// to each element.
@@ -83,7 +86,8 @@ impl<'a, A: fmt::Display, D: Dimension> fmt::Display for Array<A, D>
     }
 }
 
-impl<'a, A: fmt::Debug, D: Dimension> fmt::Debug for Array<A, D>
+impl<'a, A: fmt::Debug, S, D: Dimension> fmt::Debug for Array<A, S, D>
+where S: Deref<Target=[A]>
 {
     /// Format the array using `Debug` and apply the formatting parameters used
     /// to each element.
@@ -95,7 +99,8 @@ impl<'a, A: fmt::Debug, D: Dimension> fmt::Debug for Array<A, D>
     }
 }
 
-impl<'a, A: fmt::LowerExp, D: Dimension> fmt::LowerExp for Array<A, D>
+impl<'a, A: fmt::LowerExp, S, D: Dimension> fmt::LowerExp for Array<A, S, D>
+where S: Deref<Target=[A]>
 {
     /// Format the array using `LowerExp` and apply the formatting parameters used
     /// to each element.
@@ -107,7 +112,8 @@ impl<'a, A: fmt::LowerExp, D: Dimension> fmt::LowerExp for Array<A, D>
     }
 }
 
-impl<'a, A: fmt::UpperExp, D: Dimension> fmt::UpperExp for Array<A, D>
+impl<'a, A: fmt::UpperExp, S, D: Dimension> fmt::UpperExp for Array<A, S, D>
+where S: Deref<Target=[A]>
 {
     /// Format the array using `UpperExp` and apply the formatting parameters used
     /// to each element.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ impl<A, S, D> Array<A, S, D> where D: Dimension, S: Deref<Target=[A]>
             data: &self.data[..],
             ptr: self.ptr.clone(),
             dim: self.dim.clone(),
-            strides: self.dim.clone(),
+            strides: self.strides.clone(),
         }
     }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -123,7 +123,7 @@ fn test_negative_stride_rcarray()
         assert_eq!(vi.dim(), (2,4,2));
         // Test against sequential iterator
         let seq = [7f32,6., 5.,4.,3.,2.,1.,0.,15.,14.,13., 12.,11.,  10.,   9.,   8.];
-        for (a, b) in vi.clone().iter().zip(seq.iter()) {
+        for (a, b) in vi.iter().zip(seq.iter()) {
             assert_eq!(*a, *b);
         }
     }

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -8,12 +8,12 @@ fn broadcast_1()
 {
     let a_dim = (2, 4, 2, 2);
     let b_dim = (2, 1, 2, 1);
-    let a = Array::range(0.0, a_dim.size() as f32).reshape(a_dim);
-    let b = Array::range(0.0, b_dim.size() as f32).reshape(b_dim);
+    let a = Array::range(0.0, a_dim.size() as f32).reshape_into(a_dim);
+    let b = Array::range(0.0, b_dim.size() as f32).reshape_into(b_dim);
     assert!(b.broadcast_iter(a.dim()).is_some());
 
     let c_dim = (2, 1);
-    let c = Array::range(0.0, c_dim.size() as f32).reshape(c_dim);
+    let c = Array::range(0.0, c_dim.size() as f32).reshape_into(c_dim);
     assert!(c.broadcast_iter(1).is_none());
     assert!(c.broadcast_iter(()).is_none());
     assert!(c.broadcast_iter((2, 1)).is_some());
@@ -34,8 +34,8 @@ fn test_add()
 {
     let a_dim = (2, 4, 2, 2);
     let b_dim = (2, 1, 2, 1);
-    let mut a = Array::range(0.0, a_dim.size() as f32).reshape(a_dim);
-    let b = Array::range(0.0, b_dim.size() as f32).reshape(b_dim);
+    let mut a = Array::range(0.0, a_dim.size() as f32).reshape_into(a_dim);
+    let b = Array::range(0.0, b_dim.size() as f32).reshape_into(b_dim);
     a.iadd(&b);
     let t = Array::from_elem((), 1.0f32);
     a.iadd(&t);
@@ -45,7 +45,7 @@ fn test_add()
 fn test_add_incompat()
 {
     let a_dim = (2, 4, 2, 2);
-    let mut a = Array::range(0.0, a_dim.size() as f32).reshape(a_dim);
+    let mut a = Array::range(0.0, a_dim.size() as f32).reshape_into(a_dim);
     let incompat = Array::from_elem(3, 1.0f32);
     a.iadd(&incompat);
 }

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -18,5 +18,5 @@ fn remove_axis()
     assert_eq!(vec![4, 5, 6].remove_axis(1), vec![4, 6]);
 
     let a = Array::<f32, _>::zeros(vec![4,5,6]);
-    let b = a.subview(1, 0).reshape_into((4, 6)).reshape_into(vec![2, 3, 4]);
+    let b = a.subview(1, 0).reshape_clone((4, 6)).reshape_clone(vec![2, 3, 4]);
 }

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -18,6 +18,5 @@ fn remove_axis()
     assert_eq!(vec![4, 5, 6].remove_axis(1), vec![4, 6]);
 
     let a = Array::<f32, _>::zeros(vec![4,5,6]);
-    let a_ = a.subview(1, 0).reshape((4, 6)).unwrap();
-    let b = a_.reshape(vec![2, 3, 4]);
+    let b = a.subview(1, 0).reshape_into((4, 6)).reshape_into(vec![2, 3, 4]);
 }

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -18,6 +18,6 @@ fn remove_axis()
     assert_eq!(vec![4, 5, 6].remove_axis(1), vec![4, 6]);
 
     let a = Array::<f32, _>::zeros(vec![4,5,6]);
-    let b = a.subview(1, 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
-    
+    let a_ = a.subview(1, 0).reshape((4, 6)).unwrap();
+    let b = a_.reshape(vec![2, 3, 4]);
 }

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -12,11 +12,11 @@ fn formatting()
                "[1, 2, 3, 4]");
     assert_eq!(format!("{:4?}", a),
                "[   1,    2,    3,    4]");
-    let a = a.reshape((4, 1, 1));
+    let a = a.reshape_into((4, 1, 1));
     assert_eq!(format!("{:4?}", a),
                "[[[   1]],\n [[   2]],\n [[   3]],\n [[   4]]]");
 
-    let a = a.reshape((2, 2));
+    let a = a.reshape_into((2, 2));
     assert_eq!(format!("{}", a), 
                "[[1, 2],\n [3, 4]]");
     assert_eq!(format!("{:?}", a), 

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -21,7 +21,7 @@ fn indexed()
     for (i, elt) in a.indexed_iter() {
         assert_eq!(i, *elt as Ix);
     }
-    let a = a.reshape((2, 4, 1));
+    let a = a.reshape_into((2, 4, 1));
     let (mut i, mut j, k) = (0, 0, 0);
     for (idx, elt) in a.indexed_iter() {
         assert_eq!(idx, (i, j, k));
@@ -38,12 +38,14 @@ fn indexed()
 fn indexed2()
 {
     let a = Array::range(0.0, 8.0f32);
-    let mut iter = a.iter();
-    iter.next();
-    for (i, elt) in iter.indexed() {
-        assert_eq!(i, *elt as Ix);
+    {
+        let mut iter = a.iter();
+        iter.next();
+        for (i, elt) in iter.indexed() {
+            assert_eq!(i, *elt as Ix);
+        }
     }
-    let a = a.reshape((2, 4, 1));
+    let a = a.reshape_into((2, 4, 1));
     let (mut i, mut j, k) = (0, 0, 0);
     for (idx, elt) in a.iter().indexed() {
         assert_eq!(idx, (i, j, k));
@@ -60,7 +62,7 @@ fn indexed2()
 fn indexed3()
 {
     let a = Array::range(0.0, 8.0f32);
-    let mut a = a.reshape((2, 4, 1));
+    let mut a = a.reshape_into((2, 4, 1));
     let (mut i, mut j, k) = (0, 0, 0);
     for (idx, elt) in a.slice_iter_mut(&[S, Si(1, None, 2), S]).indexed()
     {
@@ -73,7 +75,7 @@ fn indexed3()
         *elt = -1.;
         println!("{:?}", (idx, elt));
     }
-    let a = a.reshape((2, 4));
+    let a = a.reshape_into((2, 4));
     assert_eq!( a, arr2(&[[0., -1., 2., -1.],
                           [4., -1., 6., -1.]]));
 }

--- a/tests/linalg.rs
+++ b/tests/linalg.rs
@@ -34,7 +34,7 @@ fn chol()
     assert!(ans.allclose(&chol, 0.001));
 
     // Compute bT b for a pos def matrix
-    let b = Array::range(0.0f32, 9.).reshape((3, 3));
+    let b = Array::range(0.0f32, 9.).reshape_into((3, 3));
     let mut bt = b.clone();
     bt.swap_axes(0, 1);
     let bpd = bt.mat_mul(&b);

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -14,14 +14,14 @@ fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32])
     let cc = arr1(c);
     test_oper_arr(op, aa.clone(), bb.clone(), cc.clone());
     let dim = (2, 2);
-    let aa = aa.reshape(dim);
-    let bb = bb.reshape(dim);
-    let cc = cc.reshape(dim);
+    let aa = aa.reshape_into(dim);
+    let bb = bb.reshape_into(dim);
+    let cc = cc.reshape_into(dim);
     test_oper_arr(op, aa.clone(), bb.clone(), cc.clone());
     let dim = (1, 2, 1, 2);
-    let aa = aa.reshape(dim);
-    let bb = bb.reshape(dim);
-    let cc = cc.reshape(dim);
+    let aa = aa.reshape_into(dim);
+    let bb = bb.reshape_into(dim);
+    let cc = cc.reshape_into(dim);
     test_oper_arr(op, aa.clone(), bb.clone(), cc.clone());
 }
 

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -1,7 +1,7 @@
 extern crate ndarray;
 extern crate num as libnum;
 
-use ndarray::Array;
+use ndarray::{Array, ArrayOwned};
 use ndarray::{arr0, arr1, arr2};
 
 use std::fmt;
@@ -26,7 +26,8 @@ fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32])
 }
 
 fn test_oper_arr<A: Float + fmt::Debug, D: ndarray::Dimension>
-    (op: &str, mut aa: Array<A,D>, bb: Array<A, D>, cc: Array<A, D>)
+    (op: &str, mut aa: ArrayOwned<A,D>,
+     bb: ArrayOwned<A, D>, cc: ArrayOwned<A, D>)
 {
     match op {
         "+" => {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,6 +6,6 @@ use ndarray::Array;
 fn char_array()
 {
     // test compilation & basics of non-numerical array
-    let cc = Array::from_iter("alphabet".chars()).reshape((4, 2));
-    assert!(cc.subview(1, 0) == Array::from_iter("apae".chars()));
+    let cc = Array::from_iter("alphabet".chars()).reshape_into((4, 2));
+    assert!(cc.subview(1, 0) == Array::from_iter("apae".chars()).view());
 }


### PR DESCRIPTION
Hi,

I've been experimenting with ndarrays in rust recently, and I figured I should probably try and contribute to your crate rather than create yet another experimental library in rust.

I'm a bit concerned about requiring the storage for ndarrays to be `Rc<Vec>`. Indeed, most usages of ndarrays don't require shared ownership. Also it makes working with views over foreign data a bit harder in my opinion. Also, I find the implicit copy on write semantics surprising, and would prefer having an explicit Cow if I need these semantics.

So here's my proposal: have the Array struct generic over its storage, provided that the storage can be Deref to a slice.

This then gives three main Array types: `type ArrayOwned = Array<Vec>`, `type ArrayView = Array<&[A]>`, and `type ArrayViewMut = Array<&mut [A]>`.
This makes the ownership clear, and it doesn't seem to overcomplicate the API.

What do you think?