### PR TITLE
View / Mutable View support in rblas integration

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -415,9 +415,9 @@ fn bench_mat_mul_rblas_large(bench: &mut test::Bencher)
     bench.iter(|| {
         // C ← α AB + β C
         f32::gemm(&1.,
-                  Transpose::NoTrans, &a.blas(),
-                  Transpose::NoTrans, &b.blas(),
-                  &1., &mut c.blas());
+                  Transpose::NoTrans, &a.bv(),
+                  Transpose::NoTrans, &b.bv(),
+                  &1., &mut c.bvm());
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1478,13 +1478,6 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         }
     }
 
-    /*
-    /// Set the array to the standard layout, without adjusting elements.
-    /// Useful for overwriting.
-    fn force_standard_layout(&mut self) {
-        self.strides = self.dim.default_strides();
-    }
-    */
     /// Return `true` if the array data is laid out in contiguous “C order” in
     /// memory (where the last index is the most rapidly varying).
     ///
@@ -1505,6 +1498,17 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
             }
         }
         true
+    }
+
+    #[cfg(feature = "rblas")]
+    /// Return `true` if the innermost dimension is contiguous (includes
+    /// the special cases of 0 or 1 length in that axis).
+    fn is_inner_contiguous(&self) -> bool {
+        let ndim = self.ndim();
+        if ndim == 0 {
+            return true;
+        }
+        self.shape()[ndim - 1] <= 1 || self.strides()[ndim - 1] == 1
     }
 
     /// Return the array’s data as a slice, if it is contiguous and

--- a/tests/blas.rs
+++ b/tests/blas.rs
@@ -1,13 +1,21 @@
 #![cfg(feature = "rblas")]
 
 extern crate rblas;
+extern crate num;
 #[macro_use] extern crate ndarray;
 
 use rblas::Gemm;
 use rblas::attribute::Transpose;
 
+use num::Float;
+
 use ndarray::{
     OwnedArray,
+    ArrayView,
+    ArrayViewMut,
+    arr2,
+    Ix,
+    ShapeError
 };
 
 use ndarray::blas::AsBlas;
@@ -32,10 +40,6 @@ fn strided_matrix() {
     let mut res = OwnedArray::zeros(aprim.dim());
     Gemm::gemm(&1., Transpose::NoTrans, &aprim.blas(), Transpose::NoTrans, &b.blas(),
                &0., &mut res.blas());
-    println!("{:?}", aprim);
-    println!("{:?}", b);
-    println!("{:?}", res);
-    println!("{:?}", &res - &aprim);
     assert_eq!(res, aprim);
 
     // Transposed matrix multiply
@@ -57,9 +61,105 @@ fn strided_matrix() {
     let mut res = OwnedArray::zeros(abis.dim());
     Gemm::gemm(&1., Transpose::NoTrans, &abis.blas(), Transpose::NoTrans, &b.blas(),
                &0., &mut res.blas());
-    println!("{:?}", abis);
-    println!("{:?}", b);
-    println!("{:?}", res);
-    println!("{:?}", &res - &abis);
     assert_eq!(res, abis);
+}
+
+#[test]
+fn strided_view() {
+    // smoke test, a matrix multiplication of uneven size
+    let (n, m) = (45, 33);
+    let mut a = OwnedArray::linspace(0., ((n * m) - 1) as f32, n as usize * m as usize ).into_shape((n, m)).unwrap();
+    let mut b = OwnedArray::eye(m);
+    let mut res = OwnedArray::zeros(a.dim());
+    Gemm::gemm(&1.,
+               Transpose::NoTrans, &a.blas_view_mut_checked().unwrap(),
+               Transpose::NoTrans, &b.blas_view_mut_checked().unwrap(),
+               &0., &mut res.blas_view_mut_checked().unwrap());
+    assert_eq!(res, a);
+
+    // matrix multiplication, strided
+    let aprim = a.slice(s![0..12, 0..11]);
+    let mut b = OwnedArray::eye(aprim.shape()[1]);
+    let mut res = OwnedArray::zeros(aprim.dim());
+    Gemm::gemm(&1.,
+               Transpose::NoTrans, &aprim.bv(),
+               Transpose::NoTrans, &b.blas(),
+               &0., &mut res.blas());
+    assert_eq!(res, aprim);
+
+    // test out with matrices where lower axis is strided but has length 1
+    let mut a3 = arr2(&[[1., 2., 3.]]);
+    a3.swap_axes(0, 1);
+    let mut b = OwnedArray::eye(a3.shape()[1]);
+    let mut res = arr2(&[[0., 0., 0.]]);
+    res.swap_axes(0, 1);
+    Gemm::gemm(&1.,
+               Transpose::NoTrans, &a3.bvm(),
+               Transpose::NoTrans, &b.blas(),
+               &0., &mut res.bvm());
+    assert_eq!(res, a3);
+}
+
+#[test]
+fn as_blas() {
+    let mut a = OwnedArray::<f32, _>::zeros((4, 4));
+    assert!(a.blas_view_mut_checked().is_ok());
+    a.swap_axes(0, 1);
+    assert!(a.blas_view_mut_checked().is_err());
+    a.swap_axes(0, 1);
+
+    {
+        // increased row stride
+        let mut b = a.slice_mut(s![..;2, ..]);
+        assert!(b.blas_view_mut_checked().is_ok());
+        b.bvm(); // no panic
+    }
+    {
+        // inner dimension is not contig
+        let mut b = a.slice_mut(s![.., ..;2]);
+        assert!(b.blas_view_mut_checked().is_err());
+    }
+    {
+        // inner dimension is length 1, is ok again
+        let mut b = a.slice_mut(s![.., ..;4]);
+        assert!(b.blas_view_mut_checked().is_ok());
+        b.bvm();
+    }
+}
+
+type Ix2 = (Ix, Ix);
+fn dot<F>(a: ArrayView<F, Ix2>, b: ArrayView<F, Ix2>,
+          c: &mut ArrayViewMut<F, Ix2>) -> Result<(), ShapeError>
+    where F: Gemm + Float,
+{
+    let at = Transpose::NoTrans;
+    let bt = Transpose::NoTrans;
+
+    let ba = try!(a.blas_view_checked());
+    let bb = try!(b.blas_view_checked());
+    let mut bc = try!(c.blas_view_mut_checked());
+    F::gemm(&F::one(),
+            at, &ba,
+            bt, &bb,
+            &F::zero(), &mut bc);
+    Ok(())
+}
+
+#[test]
+fn test_dot() {
+    let mut a = arr2(&[[1., 2.],
+                       [0., 3.]]);
+
+    let b = a.clone();
+    let mut res = a.clone();
+    res.assign_scalar(&0.);
+
+    dot(a.view(), b.view(), &mut res.view_mut()).unwrap();
+    println!("{:?}", res);
+
+    a.swap_axes(0, 1);
+    res.assign_scalar(&0.);
+
+    let result = dot(a.view(), b.view(), &mut res.view_mut());
+    assert!(result.is_err());
 }


### PR DESCRIPTION
Only supporting c-order array views so far (f-order support was dropped from this PR). The concern with f-order is that the rblas library that we integrate with doesn't check the ordering for each used matrix (only one of them), so it's easy to make an error if matrices are mixed.