### PR TITLE
Change mat_mul to return OwnedArray

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2173,10 +2173,10 @@ impl<A, S> ArrayBase<S, (Ix, Ix)>
     /// ```
     ///
     #[allow(deprecated)]
-    pub fn mat_mul(&self, rhs: &ArrayBase<S, (Ix, Ix)>) -> Array<A, (Ix, Ix)>
+    pub fn mat_mul(&self, rhs: &ArrayBase<S, (Ix, Ix)>) -> OwnedArray<A, (Ix, Ix)>
         where A: Copy + Ring
     {
-        // NOTE: Matrix multiplication only defined for simple types to
+        // NOTE: Matrix multiplication only defined for Copy types to
         // avoid trouble with panicking + and *, and destructors
 
         let ((m, a), (b, n)) = (self.dim, rhs.dim);
@@ -2218,7 +2218,7 @@ impl<A, S> ArrayBase<S, (Ix, Ix)>
     ///
     /// **Panics** if sizes are incompatible.
     #[allow(deprecated)]
-    pub fn mat_mul_col(&self, rhs: &ArrayBase<S, Ix>) -> Array<A, Ix>
+    pub fn mat_mul_col(&self, rhs: &ArrayBase<S, Ix>) -> OwnedArray<A, Ix>
         where A: Copy + Ring
     {
         let ((m, a), n) = (self.dim, rhs.dim);

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -109,9 +109,9 @@ pub fn least_squares<A: ComplexField>(a: &Mat<A>, b: &Col<A>) -> Col<A>
         }
     }
 
-    let aT_a = aT.mat_mul(a);
+    let aT_a = aT.mat_mul(a).into_shared();
     let mut L = cholesky(aT_a);
-    let rhs = aT.mat_mul_col(b);
+    let rhs = aT.mat_mul_col(b).into_shared();
 
     // Solve L z = aT b
     let z = subst_fw(&L, &rhs);

--- a/tests/linalg.rs
+++ b/tests/linalg.rs
@@ -37,7 +37,7 @@ fn chol()
     let b = Array::linspace(0f32, 8., 9).reshape((3, 3));
     let mut bt = b.clone();
     bt.swap_axes(0, 1);
-    let bpd = bt.mat_mul(&b);
+    let bpd = bt.mat_mul(&b).into_shared();
     println!("bpd=\n{:?}", bpd);
     let chol = ndarray::linalg::cholesky(bpd);
     println!("chol=\n{:.8?}", chol);


### PR DESCRIPTION
To maintain the same type, you need to use `.mat_mul(&b).into_shared()`
now, if you need a shared array.