### PR TITLE
Adjustments for the stride constructors & overflow error handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,6 +614,9 @@ impl<S, A, D> ArrayBase<S, D>
     /// ```
     pub fn from_elem(dim: D, elem: A) -> ArrayBase<S, D> where A: Clone
     {
+        // Note: We don't need to check the case of a size between
+        // isize::MAX -> usize::MAX; in this case, the vec constructor itself
+        // panics.
         let size = dim.size_checked().expect("Shape too large: overflow in size");
         let v = vec![elem; size];
         unsafe {

--- a/src/stride_error.rs
+++ b/src/stride_error.rs
@@ -7,7 +7,7 @@ pub enum StrideError {
     /// stride leads to out of bounds indexing
     OutOfBounds,
     /// stride leads to aliasing array elements
-    Aliasing,
+    Unsupported,
 }
 
 impl Error for StrideError {
@@ -15,7 +15,7 @@ impl Error for StrideError {
         match *self {
             StrideError::OutOfBounds =>
                 "stride leads to out of bounds indexing",
-            StrideError::Aliasing =>
+            StrideError::Unsupported =>
                 "stride leads to aliasing array elements",
         }
     }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -594,3 +594,18 @@ fn scalar_ops() {
     assert_eq!(&one << 3, 8 * &one);
     assert_eq!(3 << &one , 6 * &one);
 }
+
+#[should_panic]
+#[test]
+fn deny_wraparound_zeros() {
+    //2^64 + 5 = 18446744073709551621 = 3×7×29×36760123×823996703  (5 distinct prime factors)
+    let _five_large = OwnedArray::<f32, _>::zeros((3, 7, 29, 36760123, 823996703));
+}
+
+#[should_panic]
+#[test]
+fn deny_wraparound_reshape() {
+    //2^64 + 5 = 18446744073709551621 = 3×7×29×36760123×823996703  (5 distinct prime factors)
+    let five = OwnedArray::<f32, _>::zeros(5);
+    let _five_large = five.into_shape((3, 7, 29, 36760123, 823996703)).unwrap();
+}


### PR DESCRIPTION
Follow up on PR #59 

@vbarrielle I discovered another thing that must be checked generally, and that's wraparound when computing the number of elements in a shape.

It's a bit sad, requires adding error cases to all multidimensional constructors (eye, from_elem, zeros).

Old code would for example allow this, amusingly (in release mode, where we don't have debug assertions for this wrap around in the multiplication)

```rust
let five = OwnedArray::<f32, _>::zeros(5);
let _five_large = five.into_shape((3, 7, 29, 36760123, 823996703)).unwrap();
```