### PR TITLE
Iterate by chunks over specified axis

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -672,7 +672,7 @@ fn chunk_iter_parts<A, D: Dimension>(v: ArrayView<A, D>, axis: usize, size: usiz
     let mut last_dim = v.dim.clone();
     last_dim.slice_mut()[axis] = if rem == 0 { size } else { rem };
 
-    let last_ptr = if last_index < axis_len {
+    let last_ptr = if rem != 0 {
         unsafe {
             v.ptr.offset(stride * last_index as isize)
         }

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -631,9 +631,8 @@ pub fn new_outer_iter_mut<A, D>(v: ArrayViewMut<A, D>) -> OuterIterMut<A, D::Sma
     }
 }
 
-pub fn new_axis_iter_mut<A, D>(v: ArrayViewMut<A, D>,
-                               axis: usize
-                              ) -> OuterIterMut<A, D::Smaller>
+pub fn new_axis_iter_mut<A, D>(v: ArrayViewMut<A, D>, axis: usize)
+    -> OuterIterMut<A, D::Smaller>
     where D: RemoveAxis,
 {
     OuterIterMut {
@@ -657,10 +656,8 @@ pub struct ChunkIter<'a, A: 'a, D> {
     life: PhantomData<&'a A>,
 }
 
-fn chunk_iter_parts<A, D: Dimension>(v: ArrayView<A, D>,
-                                     axis: usize,
-                                     size: usize
-                                    ) -> (OuterIterCore<A, D>, *mut A, D)
+fn chunk_iter_parts<A, D: Dimension>(v: ArrayView<A, D>, axis: usize, size: usize)
+    -> (OuterIterCore<A, D>, *mut A, D)
 {
     let last_index = v.shape()[axis] / size;
     let rem = v.shape()[axis] % size;
@@ -688,10 +685,8 @@ fn chunk_iter_parts<A, D: Dimension>(v: ArrayView<A, D>,
     (iter, last_ptr, last_dim)
 }
 
-pub fn new_chunk_iter<A, D>(v: ArrayView<A, D>,
-                            axis: usize,
-                            size: usize,
-                            ) -> ChunkIter<A, D>
+pub fn new_chunk_iter<A, D>(v: ArrayView<A, D>, axis: usize, size: usize)
+    -> ChunkIter<A, D>
     where D: Dimension
 {
     let (iter, last_ptr, last_dim) = chunk_iter_parts(v.view(), axis, size);
@@ -709,9 +704,8 @@ macro_rules! chunk_iter_impl {
         impl<'a, A, D> $iter<'a, A, D>
             where D: Dimension
         {
-            fn get_subview(&self,
-                           iter_item: Option<*mut A>
-                          ) -> Option<$array<'a, A, D>>
+            fn get_subview(&self, iter_item: Option<*mut A>)
+                -> Option<$array<'a, A, D>>
             {
                 iter_item.map(|ptr| {
                     if ptr != self.last_ptr {
@@ -777,10 +771,8 @@ pub struct ChunkIterMut<'a, A: 'a, D> {
     life: PhantomData<&'a mut A>,
 }
 
-pub fn new_chunk_iter_mut<A, D>(v: ArrayViewMut<A, D>,
-                                axis: usize,
-                                size: usize,
-                                ) -> ChunkIterMut<A, D>
+pub fn new_chunk_iter_mut<A, D>(v: ArrayViewMut<A, D>, axis: usize, size: usize)
+    -> ChunkIterMut<A, D>
     where D: Dimension
 {
     let (iter, last_ptr, last_dim) = chunk_iter_parts(v.view(), axis, size);

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -762,5 +762,36 @@ macro_rules! chunk_iter_impl {
     )
 }
 
+/// An iterator that traverses over the specified axis
+/// and yields mutable subviews of the specified size on this axis.
+///
+/// For example, in a 2 × 8 × 3 array, if the axis of iteration
+/// is 1 and the chunk size is 2, the yielded elements
+/// are 2 × 2 × 3 subviews (and there are 4 in total).
+///
+/// Iterator element type is `ArrayViewMut<'a, A, D>`.
+pub struct ChunkIterMut<'a, A: 'a, D> {
+    iter: OuterIterCore<A, D>,
+    last_index: usize,
+    last_dim: D,
+    life: PhantomData<&'a mut A>,
+}
+
+pub fn new_chunk_iter_mut<A, D>(v: ArrayViewMut<A, D>,
+                                axis: usize,
+                                size: usize,
+                                ) -> ChunkIterMut<A, D>
+    where D: Dimension
+{
+    let (iter, last_index, last_dim) = chunk_iter_parts(v.view(), axis, size);
+
+    ChunkIterMut {
+        iter: iter,
+        last_index: last_index,
+        last_dim: last_dim,
+        life: PhantomData,
+    }
+}
 
 chunk_iter_impl!(ChunkIter, ArrayView);
+chunk_iter_impl!(ChunkIterMut, ArrayViewMut);

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -664,13 +664,13 @@ pub fn new_chunk_iter<A, D>(v: ArrayView<A, D>,
     where D: Dimension
 {
     let last_index = v.shape()[axis] / size;
-    let shape = last_index + 1;
+    let rem = v.shape()[axis] % size;
+    let shape = if rem == 0 { last_index } else { last_index + 1 };
     let stride = v.strides()[axis] * size as isize;
 
     let mut inner_dim = v.dim.clone();
     inner_dim.slice_mut()[axis] = size;
 
-    let rem = v.shape()[axis] % size;
     let mut last_dim = v.dim.clone();
     last_dim.slice_mut()[axis] = if rem == 0 { size } else { rem };
 
@@ -698,7 +698,7 @@ impl<'a, A, D> ChunkIter<'a, A, D>
                    iter_item: Option<*mut A>
                   ) -> Option<ArrayView<'a, A, D>>
     {
-        if self.iter.index != self.last_index {
+        if self.iter.index != self.last_index + 1 {
             iter_item.map(|ptr| {
                 unsafe {
                     ArrayView::new_(ptr,

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -672,7 +672,7 @@ pub fn new_chunk_iter<A, D>(v: ArrayView<A, D>,
 
     let rem = v.shape()[axis] % size;
     let mut last_dim = v.dim.clone();
-    last_dim.slice_mut()[axis] = rem;
+    last_dim.slice_mut()[axis] = if rem == 0 { size } else { rem };
 
     let iter = OuterIterCore {
         index: 0,

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -643,11 +643,11 @@ pub fn new_axis_iter_mut<A, D>(v: ArrayViewMut<A, D>,
 }
 
 /// An iterator that traverses over the specified axis
-/// and yields subviews of the specified size on this axis.
+/// and yields views of the specified size on this axis.
 ///
 /// For example, in a 2 × 8 × 3 array, if the axis of iteration
 /// is 1 and the chunk size is 2, the yielded elements
-/// are 2 × 2 × 3 subviews (and there are 4 in total).
+/// are 2 × 2 × 3 views (and there are 4 in total).
 ///
 /// Iterator element type is `ArrayView<'a, A, D>`.
 pub struct ChunkIter<'a, A: 'a, D> {
@@ -763,11 +763,11 @@ macro_rules! chunk_iter_impl {
 }
 
 /// An iterator that traverses over the specified axis
-/// and yields mutable subviews of the specified size on this axis.
+/// and yields mutable views of the specified size on this axis.
 ///
 /// For example, in a 2 × 8 × 3 array, if the axis of iteration
 /// is 1 and the chunk size is 2, the yielded elements
-/// are 2 × 2 × 3 subviews (and there are 4 in total).
+/// are 2 × 2 × 3 views (and there are 4 in total).
 ///
 /// Iterator element type is `ArrayViewMut<'a, A, D>`.
 pub struct ChunkIterMut<'a, A: 'a, D> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1458,14 +1458,17 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// ```
     /// use ndarray::Array;
+    /// use ndarray::arr3;
     ///
     /// let a = Array::from_iter(0..28).reshape((2, 7, 2));
     /// let mut iter = a.axis_chunks_iter(1, 2);
-    /// assert_eq!(2, iter.next().unwrap().shape()[1]);
-    /// assert_eq!(2, iter.next().unwrap().shape()[1]);
-    /// assert_eq!(2, iter.next().unwrap().shape()[1]);
-    /// assert_eq!(1, iter.next().unwrap().shape()[1]);
-    /// assert_eq!(None, iter.next());
+    ///
+    /// // first iteration yields a 2 × 2 × 2 view
+    /// assert_eq!(iter.next().unwrap(),
+    ///            arr3(&[[[0, 1], [2, 3]], [[14, 15], [16, 17]]]));
+    ///
+    /// // however the last element is a 2 × 1 × 2 view since 7 % 2 == 1
+    /// assert_eq!(iter.next_back().unwrap(), arr3(&[[[12, 13]], [[26, 27]]]));
     /// ```
     pub fn axis_chunks_iter(&self, axis: usize, size: usize) -> ChunkIter<A, D>
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1467,10 +1467,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// assert_eq!(1, iter.next().unwrap().shape()[1]);
     /// assert_eq!(None, iter.next());
     /// ```
-    pub fn axis_chunks_iter(&self,
-                            axis: usize,
-                            size: usize
-                           ) -> ChunkIter<A, D>
+    pub fn axis_chunks_iter(&self, axis: usize, size: usize) -> ChunkIter<A, D>
     {
         iterators::new_chunk_iter(self.view(), axis, size)
     }
@@ -1481,10 +1478,8 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// Iterator element is `ArrayViewMut<A, D>`
     ///
     /// **Panics** if `axis` is out of bounds.
-    pub fn axis_chunks_iter_mut(&mut self,
-                                axis: usize,
-                                size: usize
-                               ) -> ChunkIterMut<A, D>
+    pub fn axis_chunks_iter_mut(&mut self, axis: usize, size: usize)
+        -> ChunkIterMut<A, D>
         where S: DataMut,
     {
         iterators::new_chunk_iter_mut(self.view_mut(), axis, size)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1447,9 +1447,12 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     }
 
     /// Return an iterator that traverses over `axis` by chunks of `size`,
-    /// yielding non-overlapping subviews along that axis.
+    /// yielding non-overlapping views along that axis.
     ///
     /// Iterator element is `ArrayView<A, D>`
+    ///
+    /// The last view may have less elements if `size` does not divide
+    /// the axis' dimension.
     ///
     /// **Panics** if `axis` is out of bounds.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1455,11 +1455,12 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// ```
     /// use ndarray::Array;
     ///
-    /// let a = Array::from_iter(0..24).reshape((2, 6, 2));
+    /// let a = Array::from_iter(0..28).reshape((2, 7, 2));
     /// let mut iter = a.axis_chunks_iter(1, 2);
     /// assert_eq!(2, iter.next().unwrap().shape()[1]);
     /// assert_eq!(2, iter.next().unwrap().shape()[1]);
     /// assert_eq!(2, iter.next().unwrap().shape()[1]);
+    /// assert_eq!(1, iter.next().unwrap().shape()[1]);
     /// assert_eq!(None, iter.next());
     /// ```
     pub fn axis_chunks_iter(&self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub use iterators::{
     InnerIterMut,
     OuterIter,
     OuterIterMut,
+    ChunkIter,
 };
 
 #[allow(deprecated)]
@@ -1442,6 +1443,31 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
               D: RemoveAxis,
     {
         iterators::new_axis_iter_mut(self.view_mut(), axis)
+    }
+
+    /// Return an iterator that traverses over `axis` by chunks of `size`,
+    /// yielding non-overlapping subviews along that axis.
+    ///
+    /// Iterator element is `ArrayView<A, D>`
+    ///
+    /// **Panics** if `axis` is out of bounds.
+    ///
+    /// ```
+    /// use ndarray::Array;
+    ///
+    /// let a = Array::from_iter(0..24).reshape((2, 6, 2));
+    /// let mut iter = a.axis_chunks_iter(1, 2);
+    /// assert_eq!(2, iter.next().unwrap().shape()[1]);
+    /// assert_eq!(2, iter.next().unwrap().shape()[1]);
+    /// assert_eq!(2, iter.next().unwrap().shape()[1]);
+    /// assert_eq!(None, iter.next());
+    /// ```
+    pub fn axis_chunks_iter(&self,
+                            axis: usize,
+                            size: usize
+                            ) -> ChunkIter<A, D>
+    {
+        iterators::new_chunk_iter(self.view(), axis, size)
     }
 
     // Return (length, stride) for diagonal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub use iterators::{
     OuterIter,
     OuterIterMut,
     ChunkIter,
+    ChunkIterMut,
 };
 
 #[allow(deprecated)]
@@ -1466,9 +1467,24 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn axis_chunks_iter(&self,
                             axis: usize,
                             size: usize
-                            ) -> ChunkIter<A, D>
+                           ) -> ChunkIter<A, D>
     {
         iterators::new_chunk_iter(self.view(), axis, size)
+    }
+
+    /// Return an iterator that traverses over `axis` by chunks of `size`,
+    /// yielding non-overlapping mutable subviews along that axis.
+    ///
+    /// Iterator element is `ArrayViewMut<A, D>`
+    ///
+    /// **Panics** if `axis` is out of bounds.
+    pub fn axis_chunks_iter_mut(&mut self,
+                                axis: usize,
+                                size: usize
+                               ) -> ChunkIterMut<A, D>
+        where S: DataMut,
+    {
+        iterators::new_chunk_iter_mut(self.view_mut(), axis, size)
     }
 
     // Return (length, stride) for diagonal

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -321,6 +321,9 @@ fn axis_chunks_iter() {
     assert_eq!(it.next().unwrap(),
                arr3(&[[[12, 13]], [[26, 27]]]));
     assert_eq!(it.next(), None);
+
+    let mut it = a.axis_chunks_iter(1, 2).rev();
+    assert_eq!(it.next().unwrap(), arr3(&[[[12, 13]], [[26, 27]]]));
 }
 
 #[test]

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -295,6 +295,35 @@ fn axis_iter_mut() {
 }
 
 #[test]
+fn axis_chunks_iter() {
+    let a = Array::from_iter(0..24);
+    let a = a.reshape((2, 6, 2));
+
+    let mut it = a.axis_chunks_iter(1, 2);
+    assert_eq!(it.next().unwrap(),
+               arr3(&[[[0, 1], [2, 3]], [[12, 13], [14, 15]]]));
+    assert_eq!(it.next().unwrap(),
+               arr3(&[[[4, 5], [6, 7]], [[16, 17], [18, 19]]]));
+    assert_eq!(it.next().unwrap(),
+               arr3(&[[[8, 9], [10, 11]], [[20, 21], [22, 23]]]));
+    assert_eq!(it.next(), None);
+
+    let a = Array::from_iter(0..28);
+    let a = a.reshape((2, 7, 2));
+
+    let mut it = a.axis_chunks_iter(1, 2);
+    assert_eq!(it.next().unwrap(),
+               arr3(&[[[0, 1], [2, 3]], [[14, 15], [16, 17]]]));
+    assert_eq!(it.next().unwrap(),
+               arr3(&[[[4, 5], [6, 7]], [[18, 19], [20, 21]]]));
+    assert_eq!(it.next().unwrap(),
+               arr3(&[[[8, 9], [10, 11]], [[22, 23], [24, 25]]]));
+    assert_eq!(it.next().unwrap(),
+               arr3(&[[[12, 13]], [[26, 27]]]));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
 fn outer_iter_size_hint() {
     // Check that the size hint is correctly computed
     let a = Array::from_iter(0..24).reshape((4, 3, 2));

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -324,6 +324,12 @@ fn axis_chunks_iter() {
 
     let mut it = a.axis_chunks_iter(1, 2).rev();
     assert_eq!(it.next().unwrap(), arr3(&[[[12, 13]], [[26, 27]]]));
+    assert_eq!(it.next().unwrap(),
+               arr3(&[[[8, 9], [10, 11]], [[22, 23], [24, 25]]]));
+    assert_eq!(it.next().unwrap(),
+               arr3(&[[[4, 5], [6, 7]], [[18, 19], [20, 21]]]));
+    assert_eq!(it.next().unwrap(),
+               arr3(&[[[0, 1], [2, 3]], [[14, 15], [16, 17]]]));
 }
 
 #[test]

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -333,6 +333,10 @@ fn axis_chunks_iter() {
 #[test]
 fn axis_chunks_iter_corner_cases() {
     // examples provided by @bluss in PR #65
+    // these tests highlight corner cases of the axis_chunks_iter implementation
+    // and enable checking if no pointer offseting is out of bounds. However
+    // checking the absence of of out of bounds offseting cannot (?) be
+    // done automatically, so one has to launch this test in a debugger.
     let a = Array::<f32, _>::linspace(0., 7., 8).reshape((8, 1));
     let a = a.slice(s![..;-1,..]);
     let it = a.axis_chunks_iter(0, 8);
@@ -343,10 +347,13 @@ fn axis_chunks_iter_corner_cases() {
                       arr2(&[[4.], [3.], [2.]]),
                       arr2(&[[1.], [0.]])]);
 
-    let a = Array::<f32, _>::zeros((8, 2));
-    let a = a.slice(s![1..;2,..]);
+    let b = Array::<f32, _>::zeros((8, 2));
+    let a = b.slice(s![1..;2,..]);
     let it = a.axis_chunks_iter(0, 8);
     assert_equal(it, vec![a.view()]);
+
+    let it = a.axis_chunks_iter(0, 1);
+    assert_equal(it, vec![Array::zeros((1, 2)); 4]);
 }
 
 #[test]

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -299,37 +299,28 @@ fn axis_chunks_iter() {
     let a = Array::from_iter(0..24);
     let a = a.reshape((2, 6, 2));
 
-    let mut it = a.axis_chunks_iter(1, 2);
-    assert_eq!(it.next().unwrap(),
-               arr3(&[[[0, 1], [2, 3]], [[12, 13], [14, 15]]]));
-    assert_eq!(it.next().unwrap(),
-               arr3(&[[[4, 5], [6, 7]], [[16, 17], [18, 19]]]));
-    assert_eq!(it.next().unwrap(),
-               arr3(&[[[8, 9], [10, 11]], [[20, 21], [22, 23]]]));
-    assert_eq!(it.next(), None);
+    let it = a.axis_chunks_iter(1, 2);
+    assert_equal(it,
+                 vec![arr3(&[[[0, 1], [2, 3]], [[12, 13], [14, 15]]]),
+                      arr3(&[[[4, 5], [6, 7]], [[16, 17], [18, 19]]]),
+                      arr3(&[[[8, 9], [10, 11]], [[20, 21], [22, 23]]])]);
 
     let a = Array::from_iter(0..28);
     let a = a.reshape((2, 7, 2));
 
-    let mut it = a.axis_chunks_iter(1, 2);
-    assert_eq!(it.next().unwrap(),
-               arr3(&[[[0, 1], [2, 3]], [[14, 15], [16, 17]]]));
-    assert_eq!(it.next().unwrap(),
-               arr3(&[[[4, 5], [6, 7]], [[18, 19], [20, 21]]]));
-    assert_eq!(it.next().unwrap(),
-               arr3(&[[[8, 9], [10, 11]], [[22, 23], [24, 25]]]));
-    assert_eq!(it.next().unwrap(),
-               arr3(&[[[12, 13]], [[26, 27]]]));
-    assert_eq!(it.next(), None);
+    let it = a.axis_chunks_iter(1, 2);
+    assert_equal(it,
+                 vec![arr3(&[[[0, 1], [2, 3]], [[14, 15], [16, 17]]]),
+                      arr3(&[[[4, 5], [6, 7]], [[18, 19], [20, 21]]]),
+                      arr3(&[[[8, 9], [10, 11]], [[22, 23], [24, 25]]]),
+                      arr3(&[[[12, 13]], [[26, 27]]])]);
 
-    let mut it = a.axis_chunks_iter(1, 2).rev();
-    assert_eq!(it.next().unwrap(), arr3(&[[[12, 13]], [[26, 27]]]));
-    assert_eq!(it.next().unwrap(),
-               arr3(&[[[8, 9], [10, 11]], [[22, 23], [24, 25]]]));
-    assert_eq!(it.next().unwrap(),
-               arr3(&[[[4, 5], [6, 7]], [[18, 19], [20, 21]]]));
-    assert_eq!(it.next().unwrap(),
-               arr3(&[[[0, 1], [2, 3]], [[14, 15], [16, 17]]]));
+    let it = a.axis_chunks_iter(1, 2).rev();
+    assert_equal(it,
+                 vec![arr3(&[[[12, 13]], [[26, 27]]]),
+                      arr3(&[[[8, 9], [10, 11]], [[22, 23], [24, 25]]]),
+                      arr3(&[[[4, 5], [6, 7]], [[18, 19], [20, 21]]]),
+                      arr3(&[[[0, 1], [2, 3]], [[14, 15], [16, 17]]])]);
 }
 
 #[test]

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -321,6 +321,12 @@ fn axis_chunks_iter() {
                       arr3(&[[[8, 9], [10, 11]], [[22, 23], [24, 25]]]),
                       arr3(&[[[4, 5], [6, 7]], [[18, 19], [20, 21]]]),
                       arr3(&[[[0, 1], [2, 3]], [[14, 15], [16, 17]]])]);
+
+    let it = a.axis_chunks_iter(1, 7);
+    assert_equal(it, vec![a.view()]);
+
+    let it = a.axis_chunks_iter(1, 9);
+    assert_equal(it, vec![a.view()]);
 }
 
 #[test]

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -324,6 +324,17 @@ fn axis_chunks_iter() {
 }
 
 #[test]
+fn axis_chunks_iter_mut() {
+    let a = Array::from_iter(0..24);
+    let mut a = a.reshape((2, 6, 2));
+
+    let mut it = a.axis_chunks_iter_mut(1, 2);
+    let mut col0 = it.next().unwrap();
+    col0[[0, 0, 0]] = 42;
+    assert_eq!(col0, arr3(&[[[42, 1], [2, 3]], [[12, 13], [14, 15]]]));
+}
+
+#[test]
 fn outer_iter_size_hint() {
     // Check that the size hint is correctly computed
     let a = Array::from_iter(0..24).reshape((4, 3, 2));

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -9,6 +9,7 @@ use ndarray::{
     Data,
     Dimension,
     aview1,
+    arr2,
     arr3,
 };
 
@@ -326,6 +327,25 @@ fn axis_chunks_iter() {
     assert_equal(it, vec![a.view()]);
 
     let it = a.axis_chunks_iter(1, 9);
+    assert_equal(it, vec![a.view()]);
+}
+
+#[test]
+fn axis_chunks_iter_corner_cases() {
+    // examples provided by @bluss in PR #65
+    let a = Array::<f32, _>::linspace(0., 7., 8).reshape((8, 1));
+    let a = a.slice(s![..;-1,..]);
+    let it = a.axis_chunks_iter(0, 8);
+    assert_equal(it, vec![a.view()]);
+    let it = a.axis_chunks_iter(0, 3);
+    assert_equal(it,
+                 vec![arr2(&[[7.], [6.], [5.]]),
+                      arr2(&[[4.], [3.], [2.]]),
+                      arr2(&[[1.], [0.]])]);
+
+    let a = Array::<f32, _>::zeros((8, 2));
+    let a = a.slice(s![1..;2,..]);
+    let it = a.axis_chunks_iter(0, 8);
     assert_equal(it, vec![a.view()]);
 }
 


### PR DESCRIPTION
This relies on iterating using `OuterIterCore` while monitoring the location of the current index. When the iterator detects the last chunk, a different shape is used.

I'm not sure this is the proper design yet, it works for forward iteration but probably not for reversed iteration.