### PR TITLE
Support for transposition

### DIFF
--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -210,18 +210,6 @@ pub unsafe trait Dimension : Clone + Eq {
         strides
     }
 
-    /// Return a Dimension with inverted values, useful for transposition
-    fn reverse(&self) -> Self {
-        let mut reversed = self.clone();
-        {
-            let iter = reversed.slice_mut().iter_mut().rev().zip(self.slice());
-            for (rev, &cur) in iter {
-                *rev = cur;
-            }
-        }
-        reversed
-    }
-
     #[inline]
     fn first_index(&self) -> Option<Self>
     {

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -210,6 +210,18 @@ pub unsafe trait Dimension : Clone + Eq {
         strides
     }
 
+    /// Return a Dimension with inverted values, useful for transposition
+    fn reverse(&self) -> Self {
+        let mut reversed = self.clone();
+        {
+            let iter = reversed.slice_mut().iter_mut().rev().zip(self.slice());
+            for (rev, &cur) in iter {
+                *rev = cur;
+            }
+        }
+        reversed
+    }
+
     #[inline]
     fn first_index(&self) -> Option<Self>
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1570,15 +1570,15 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// Transposition reverses the order of the axes and strides while
     /// retaining the same data.
-    pub fn transpose(self) -> ArrayBase<S, D>
+    pub fn transpose(mut self) -> ArrayBase<S, D>
     {
-        let dim = self.dim.reverse();
-        let strides = self.strides.reverse();
+        self.dim.slice_mut().reverse();
+        self.strides.slice_mut().reverse();
         ArrayBase {
             ptr: self.ptr,
             data: self.data,
-            dim: dim,
-            strides: strides
+            dim: self.dim,
+            strides: self.strides
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1556,6 +1556,35 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         }
     }
 
+    /// Get a transposed view of this array.
+    ///
+    /// Transposition reverses the order of the axes and strides while
+    /// retaining the same data.
+    pub fn transpose_view(&self) -> ArrayView<A, D>
+    {
+        let dim = self.dim.reverse();
+        let strides = self.strides.reverse();
+        // safe because transposing an array exposes the same memory
+        unsafe {
+            ArrayView::new_(self.ptr, dim, strides)
+        }
+    }
+
+    /// Get a mutable transposed view of this array.
+    ///
+    /// Transposition reverses the order of the axes and strides while
+    /// retaining the same data.
+    pub fn transpose_view_mut(&mut self) -> ArrayViewMut<A, D>
+        where S: DataMut
+    {
+        let dim = self.dim.reverse();
+        let strides = self.strides.reverse();
+        // safe because transposing an array exposes the same memory
+        unsafe {
+            ArrayViewMut::new_(self.ptr, dim, strides)
+        }
+    }
+
     /// Transform the array into `shape`; any shape with the same number of
     /// elements is accepted.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1566,52 +1566,32 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         }
     }
 
-    /// Get a transposed view of this array.
+    /// Transpose this array.
     ///
     /// Transposition reverses the order of the axes and strides while
     /// retaining the same data.
-    pub fn transpose_view(&self) -> ArrayView<A, D>
+    pub fn transpose(self) -> ArrayBase<S, D>
     {
         let dim = self.dim.reverse();
         let strides = self.strides.reverse();
-        // safe because transposing an array exposes the same memory
-        unsafe {
-            ArrayView::new_(self.ptr, dim, strides)
+        ArrayBase {
+            ptr: self.ptr,
+            data: self.data,
+            dim: dim,
+            strides: strides
         }
     }
 
-    /// Get a mutable transposed view of this array.
-    ///
-    /// Transposition reverses the order of the axes and strides while
-    /// retaining the same data.
-    pub fn transpose_view_mut(&mut self) -> ArrayViewMut<A, D>
-        where S: DataMut
-    {
-        let dim = self.dim.reverse();
-        let strides = self.strides.reverse();
-        // safe because transposing an array exposes the same memory
-        unsafe {
-            ArrayViewMut::new_(self.ptr, dim, strides)
-        }
-    }
-
-    /// Consume this array and get its transposition.
-    /// If the array storage was shared (Rc based storage), the underlying
-    /// data will be copied. Otherwise this method will not allocate.
-    ///
-    /// Transposition reverses the order of the axes and strides while
-    /// retaining the same data.
-    pub fn transpose_into(mut self) -> OwnedArray<A, D>
+    pub fn into_owned(mut self) -> OwnedArray<A, D>
         where S: DataOwned + DataMut,
               A: Clone + Debug
     {
         self.ensure_unique();
-        let dim = self.dim.reverse();
-        let strides = self.strides.reverse();
         let vec = self.data.into_owned();
-        // transposing does not change the safety of the strides
         unsafe {
-            OwnedArray::from_vec_dim_stride_unchecked(dim, strides, vec)
+            OwnedArray::from_vec_dim_stride_unchecked(self.dim,
+                                                      self.strides,
+                                                      vec)
         }
     }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -545,6 +545,17 @@ fn transpose_view_mut() {
 }
 
 #[test]
+fn transpose_into() {
+    let a = arr2(&[[1, 2],
+                   [3, 4]]);
+    let a_ = a.clone();
+
+    let at = a.transpose_into();
+
+    assert_eq!(at, a_.transpose_view());
+}
+
+#[test]
 fn reshape() {
     let data = [1, 2, 3, 4, 5, 6, 7, 8];
     let v = aview1(&data);

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -520,12 +520,12 @@ fn aview_mut() {
 fn transpose_view() {
     let a = arr2(&[[1, 2],
                    [3, 4]]);
-    let at = a.transpose_view();
+    let at = a.view().transpose();
     assert_eq!(at, arr2(&[[1, 3], [2, 4]]));
 
     let a = arr2(&[[1, 2, 3],
                    [4, 5, 6]]);
-    let at = a.transpose_view();
+    let at = a.view().transpose();
     assert_eq!(at, arr2(&[[1, 4], [2, 5], [3, 6]]));
 }
 
@@ -533,13 +533,13 @@ fn transpose_view() {
 fn transpose_view_mut() {
     let mut a = arr2(&[[1, 2],
                        [3, 4]]);
-    let mut at = a.transpose_view_mut();
+    let mut at = a.view_mut().transpose();
     at[[0, 1]] = 5;
     assert_eq!(at, arr2(&[[1, 5], [2, 4]]));
 
     let mut a = arr2(&[[1, 2, 3],
                        [4, 5, 6]]);
-    let mut at = a.transpose_view_mut();
+    let mut at = a.view_mut().transpose();
     at[[2, 1]] = 7;
     assert_eq!(at, arr2(&[[1, 4], [2, 5], [3, 7]]));
 }
@@ -550,9 +550,9 @@ fn transpose_into() {
                    [3, 4]]);
     let a_ = a.clone();
 
-    let at = a.transpose_into();
+    let at = a.into_owned().transpose();
 
-    assert_eq!(at, a_.transpose_view());
+    assert_eq!(at, a_.view().transpose());
 }
 
 #[test]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -545,17 +545,6 @@ fn transpose_view_mut() {
 }
 
 #[test]
-fn transpose_into() {
-    let a = arr2(&[[1, 2],
-                   [3, 4]]);
-    let a_ = a.clone();
-
-    let at = a.into_owned().transpose();
-
-    assert_eq!(at, a_.view().transpose());
-}
-
-#[test]
 fn reshape() {
     let data = [1, 2, 3, 4, 5, 6, 7, 8];
     let v = aview1(&data);

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -517,6 +517,34 @@ fn aview_mut() {
 }
 
 #[test]
+fn transpose_view() {
+    let a = arr2(&[[1, 2],
+                   [3, 4]]);
+    let at = a.transpose_view();
+    assert_eq!(at, arr2(&[[1, 3], [2, 4]]));
+
+    let a = arr2(&[[1, 2, 3],
+                   [4, 5, 6]]);
+    let at = a.transpose_view();
+    assert_eq!(at, arr2(&[[1, 4], [2, 5], [3, 6]]));
+}
+
+#[test]
+fn transpose_view_mut() {
+    let mut a = arr2(&[[1, 2],
+                       [3, 4]]);
+    let mut at = a.transpose_view_mut();
+    at[[0, 1]] = 5;
+    assert_eq!(at, arr2(&[[1, 5], [2, 4]]));
+
+    let mut a = arr2(&[[1, 2, 3],
+                       [4, 5, 6]]);
+    let mut at = a.transpose_view_mut();
+    at[[2, 1]] = 7;
+    assert_eq!(at, arr2(&[[1, 4], [2, 5], [3, 7]]));
+}
+
+#[test]
 fn reshape() {
     let data = [1, 2, 3, 4, 5, 6, 7, 8];
     let v = aview1(&data);


### PR DESCRIPTION
This PR adds support for having a transposed view (mutable or not) of an array. We probably also want to have a transposition with copy that doesn't change the storage order.