### PR TITLE
Small changes and an improvement to operations with 0-dim arrays.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,13 @@ How to use with cargo::
 Recent Changes
 --------------
 
+- master
+
+  - Improve arithmetic operations where the RHS is a broadcast 0-dimensional
+    array.
+  - Add read-only and read-write array views to the ``rblas`` integration.
+    Added methods ``AsBlas::{blas_view_checked, blas_view_mut_checked, bv, bvm}``.
+
 - 0.4.0-alpha.2
 
   - Add ``ArrayBase::reversed_axes`` which transposes an array.

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -318,6 +318,17 @@ fn add_2d_broadcast_0_to_2(bench: &mut test::Bencher)
     });
 }
 
+// This is for comparison with add_2d_broadcast_0_to_2
+#[bench]
+fn add_2d_0_to_2_iadd_scalar(bench: &mut test::Bencher)
+{
+    let mut a = OwnedArray::<i32, _>::zeros((64, 64));
+    let n = black_box(0);
+    bench.iter(|| {
+        a.iadd_scalar(&n);
+    });
+}
+
 #[bench]
 fn add_2d_transposed(bench: &mut test::Bencher)
 {

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -152,8 +152,18 @@ impl<'a, S, D> hash::Hash for ArrayBase<S, D>
     fn hash<H: hash::Hasher>(&self, state: &mut H)
     {
         self.shape().hash(state);
-        for elt in self.iter() {
-            elt.hash(state)
+        if let Some(self_s) = self.as_slice() {
+            hash::Hash::hash_slice(self_s, state);
+        } else {
+            for row in self.inner_iter() {
+                if let Some(row_s) = row.as_slice() {
+                    hash::Hash::hash_slice(row_s, state);
+                } else {
+                    for elt in row {
+                        elt.hash(state)
+                    }
+                }
+            }
         }
     }
 }

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -128,8 +128,8 @@ fn stride_offset_checked_arithmetic<D>(dim: &D, strides: &D, index: &D) -> Optio
 ///
 /// `unsafe` because of the assumptions in the default methods.
 ///
-/// ***Don't implement this trait, it's internal to the crate and will
-/// evolve at will.***
+/// ***Don't implement or call methods in this trait, its interface is internal
+/// to the crate and will evolve at will.***
 pub unsafe trait Dimension : Clone + Eq {
     /// `SliceArg` is the type which is used to specify slicing for this
     /// dimension.
@@ -146,23 +146,28 @@ pub unsafe trait Dimension : Clone + Eq {
     /// The easiest way to create a `&SliceArg` is using the macro
     /// [`s![]`](macro.s!.html).
     type SliceArg: ?Sized + AsRef<[Si]>;
+    #[doc(hidden)]
     fn ndim(&self) -> usize;
+    #[doc(hidden)]
     fn slice(&self) -> &[Ix] {
         unsafe {
             slice::from_raw_parts(self as *const _ as *const Ix, self.ndim())
         }
     }
 
+    #[doc(hidden)]
     fn slice_mut(&mut self) -> &mut [Ix] {
         unsafe {
             slice::from_raw_parts_mut(self as *mut _ as *mut Ix, self.ndim())
         }
     }
 
+    #[doc(hidden)]
     fn size(&self) -> usize {
         self.slice().iter().fold(1, |s, &a| s * a as usize)
     }
 
+    #[doc(hidden)]
     /// Compute the size while checking for overflow
     fn size_checked(&self) -> Option<usize> {
         self.slice().iter().fold(Some(1), |s, &a| {
@@ -170,6 +175,7 @@ pub unsafe trait Dimension : Clone + Eq {
         })
     }
 
+    #[doc(hidden)]
     fn default_strides(&self) -> Self {
         // Compute default array strides
         // Shape (a, b, c) => Give strides (b * c, c, 1)
@@ -190,6 +196,7 @@ pub unsafe trait Dimension : Clone + Eq {
         strides
     }
 
+    #[doc(hidden)]
     fn fortran_strides(&self) -> Self {
         // Compute fortran array strides
         // Shape (a, b, c) => Give strides (1, a, a * b)
@@ -210,9 +217,9 @@ pub unsafe trait Dimension : Clone + Eq {
         strides
     }
 
+    #[doc(hidden)]
     #[inline]
-    fn first_index(&self) -> Option<Self>
-    {
+    fn first_index(&self) -> Option<Self> {
         for ax in self.slice().iter() {
             if *ax == 0 {
                 return None
@@ -225,6 +232,7 @@ pub unsafe trait Dimension : Clone + Eq {
         Some(index)
     }
 
+    #[doc(hidden)]
     /// Iteration -- Use self as size, and return next index after `index`
     /// or None if there are no more.
     // FIXME: use &Self for index or even &mut?
@@ -247,6 +255,7 @@ pub unsafe trait Dimension : Clone + Eq {
         } else { None }
     }
 
+    #[doc(hidden)]
     /// Return stride offset for index.
     fn stride_offset(index: &Self, strides: &Self) -> isize
     {
@@ -257,6 +266,7 @@ pub unsafe trait Dimension : Clone + Eq {
         offset
     }
 
+    #[doc(hidden)]
     /// Return stride offset for this dimension and index.
     fn stride_offset_checked(&self, strides: &Self, index: &Self) -> Option<isize>
     {
@@ -273,6 +283,7 @@ pub unsafe trait Dimension : Clone + Eq {
         Some(offset)
     }
 
+    #[doc(hidden)]
     /// Modify dimension, strides and return data pointer offset
     ///
     /// **Panics** if `slices` does not correspond to the number of axes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1890,6 +1890,13 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         }
     }
 
+    fn zip_mut_with_elem<B, F>(&mut self, rhs_elem: &B, mut f: F)
+        where S: DataMut,
+              F: FnMut(&mut A, &B)
+    {
+        self.unordered_foreach_mut(move |elt| f(elt, rhs_elem));
+    }
+
     // FIXME: Guarantee the order here or not?
     /// Traverse two arrays in unspecified order, in lock step,
     /// calling the closure `f` on each element pair.
@@ -1898,22 +1905,20 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// **Panics** if broadcasting isn’t possible.
     #[inline]
-    pub fn zip_mut_with<B, S2, E, F>(&mut self, rhs: &ArrayBase<S2, E>, mut f: F)
+    pub fn zip_mut_with<B, S2, E, F>(&mut self, rhs: &ArrayBase<S2, E>, f: F)
         where S: DataMut,
               S2: Data<Elem=B>,
               E: Dimension,
               F: FnMut(&mut A, &B)
     {
-        if self.dim.ndim() == rhs.dim.ndim() && self.shape() == rhs.shape() {
-            self.zip_with_mut_same_shape(rhs, f);
-        } else if rhs.dim.ndim() == 0 {
+        if rhs.dim.ndim() == 0 {
             // Skip broadcast from 0-dim array
-            // FIXME: Order
             unsafe {
                 let rhs_elem = &*rhs.ptr;
-                let f_ = &mut f;
-                self.unordered_foreach_mut(move |elt| f_(elt, rhs_elem));
+                self.zip_mut_with_elem(rhs_elem, f);
             }
+        } else if self.dim.ndim() == rhs.dim.ndim() && self.shape() == rhs.shape() {
+            self.zip_with_mut_same_shape(rhs, f);
         } else {
             let rhs_broadcast = rhs.broadcast_unwrap(self.dim());
             self.zip_with_mut_outer_iter(&rhs_broadcast, f);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1401,7 +1401,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     }
 
     /// Return an iterator that traverses over `axis` by chunks of `size`,
-    /// yielding non-overlapping mutable subviews along that axis.
+    /// yielding non-overlapping read-write views along that axis.
     ///
     /// Iterator element is `ArrayViewMut<A, D>`
     ///
@@ -1745,7 +1745,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         self.strides.slice_mut().swap(ax, bx);
     }
 
-    /// Transpose the array by reversing all axes.
+    /// Transpose the array by reversing axes.
     ///
     /// Transposition reverses the order of the axes (dimensions and strides)
     /// while retaining the same data.

--- a/src/si.rs
+++ b/src/si.rs
@@ -5,7 +5,7 @@ use super::{Ixs};
 // [0,:] -- first row of matrix
 // [:,0] -- first column of matrix
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, PartialEq, Eq, Hash, Debug)]
 /// A slice, a description of a range of an array axis.
 ///
 /// Fields are `begin`, `end` and `stride`, where
@@ -63,6 +63,11 @@ impl Si {
     pub fn step(self, step: Ixs) -> Self {
         Si(self.0, self.1, self.2 * step)
     }
+}
+
+impl Clone for Si {
+    #[inline]
+    fn clone(&self) -> Self { *self }
 }
 
 /// Slice value for the full range of an axis.


### PR DESCRIPTION
- Hide all methods in the `Dimension` trait, because they are not for end users (yet, at least).
- Improve `a @ b` where b is a zero dimensional array (contains 1 element) and `@` is arbitrary arithmetic operation.