### PR TITLE
Rename Array to RcArray (old name is deprecated)

### DIFF
--- a/examples/life.rs
+++ b/examples/life.rs
@@ -2,7 +2,7 @@
 extern crate ndarray;
 
 use ndarray::{
-    Array,
+    RcArray,
     Ix,
 };
 
@@ -14,12 +14,12 @@ const INPUT: &'static [u8] = include_bytes!("life.txt");
 const N: usize = 100;
 //const N: usize = 8;
 
-type Board = Array<u8, Ix2>;
+type Board = RcArray<u8, Ix2>;
 
 fn parse(x: &[u8]) -> Board {
     // make a border of 0 cells
-    let mut map = Array::from_elem(((N + 2) as Ix, (N + 2) as Ix), 0);
-    let a: Array<u8, Ix> = x.iter().filter_map(|&b| match b {
+    let mut map = RcArray::from_elem(((N + 2) as Ix, (N + 2) as Ix), 0);
+    let a: RcArray<u8, Ix> = x.iter().filter_map(|&b| match b {
         b'#' => Some(1),
         b'.' => Some(0),
         _ => None,

--- a/examples/linalg.rs
+++ b/examples/linalg.rs
@@ -11,13 +11,13 @@ use libnum::Float;
 use libnum::Complex;
 use std::ops::{Add, Sub, Mul, Div};
 
-use ndarray::{Array, Ix};
+use ndarray::{RcArray, Ix};
 use ndarray::{arr1, arr2};
 
 /// Column vector.
-pub type Col<A> = Array<A, Ix>;
+pub type Col<A> = RcArray<A, Ix>;
 /// Rectangular matrix.
-pub type Mat<A> = Array<A, (Ix, Ix)>;
+pub type Mat<A> = RcArray<A, (Ix, Ix)>;
 
 /// Trait union for a ring with 1.
 pub trait Ring : Clone + Zero + Add<Output=Self> + Sub<Output=Self>
@@ -79,7 +79,7 @@ fn chol()
     assert!(ans.allclose(&chol, 0.001));
 
     // Compute bT b for a pos def matrix
-    let b = Array::linspace(0f32, 8., 9).reshape((3, 3));
+    let b = RcArray::linspace(0f32, 8., 9).reshape((3, 3));
     let mut bt = b.clone();
     bt.swap_axes(0, 1);
     let bpd = bt.mat_mul(&b).into_shared();

--- a/src/arrayserialize.rs
+++ b/src/arrayserialize.rs
@@ -9,11 +9,11 @@ use super::{
 };
 
 struct AVisitor<'a, A: 'a, D: 'a> {
-    arr: &'a Array<A, D>,
+    arr: &'a RcArray<A, D>,
     state: u32,
 }
 
-impl<A: Serialize, D: Serialize> Serialize for Array<A, D>
+impl<A: Serialize, D: Serialize> Serialize for RcArray<A, D>
     where D: Dimension
 {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -14,7 +14,7 @@
 //! use rblas::Gemv;
 //! use rblas::attribute::Transpose;
 //!
-//! use ndarray::{arr1, arr2, Array};
+//! use ndarray::{arr1, arr2};
 //! use ndarray::blas::AsBlas;
 //!
 //! fn main() {
@@ -145,7 +145,7 @@ pub trait AsBlas<A, S, D> {
     /// Elements are copied if needed to produce a contiguous matrix.<br>
     /// The result is always mutable, due to the requirement of having write
     /// access to update the layout either way. Breaks sharing if the array is
-    /// an `Array`.
+    /// an `RcArray`.
     ///
     /// **Errors** if any dimension is larger than `c_int::MAX`.
     fn blas_checked(&mut self) -> Result<BlasArrayViewMut<A, D>, ShapeError>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,6 +522,12 @@ unsafe impl<A> DataOwned for Rc<Vec<A>> {
 
 /// Array where the data is reference counted and copy on write, it
 /// can act as both an owner as the data as well as a lightweight view.
+pub type RcArray<A, D> = ArrayBase<Rc<Vec<A>>, D>;
+#[cfg_attr(has_deprecated, deprecated(note="`Array` is deprecated! Renamed to `RcArray`."))]
+/// ***Deprecated: Use `RcArray` instead***
+///
+/// Array where the data is reference counted and copy on write, it
+/// can act as both an owner as the data as well as a lightweight view.
 pub type Array<A, D> = ArrayBase<Rc<Vec<A>>, D>;
 
 /// Array where the data is owned uniquely.

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -4,7 +4,7 @@
 #[macro_use]
 extern crate ndarray;
 
-use ndarray::{Array, S, Si,
+use ndarray::{RcArray, S, Si,
     OwnedArray,
 };
 use ndarray::{arr0, arr1, arr2,
@@ -18,12 +18,12 @@ use ndarray::Indexes;
 #[test]
 fn test_matmul_rcarray()
 {
-    let mut A = Array::<usize, _>::zeros((2, 3));
+    let mut A = RcArray::<usize, _>::zeros((2, 3));
     for (i, elt) in A.iter_mut().enumerate() {
         *elt = i;
     }
 
-    let mut B = Array::<usize, _>::zeros((3, 4));
+    let mut B = RcArray::<usize, _>::zeros((3, 4));
     for (i, elt) in B.iter_mut().enumerate() {
         *elt = i;
     }
@@ -33,7 +33,7 @@ fn test_matmul_rcarray()
     println!("B = \n{:?}", B);
     println!("A x B = \n{:?}", c);
     unsafe {
-        let result = Array::from_vec_dim_unchecked((2, 4), vec![20, 23, 26, 29, 56, 68, 80, 92]);
+        let result = RcArray::from_vec_dim_unchecked((2, 4), vec![20, 23, 26, 29, 56, 68, 80, 92]);
         assert_eq!(c.shape(), result.shape());
         assert!(c.iter().zip(result.iter()).all(|(a,b)| a == b));
         assert!(c == result);
@@ -44,10 +44,10 @@ fn test_matmul_rcarray()
 fn test_mat_mul() {
     // smoke test, a big matrix multiplication of uneven size
     let (n, m) = (45, 33);
-    let a = Array::linspace(0., ((n * m) - 1) as f32, n as usize * m as usize ).reshape((n, m));
-    let b = Array::eye(m);
+    let a = RcArray::linspace(0., ((n * m) - 1) as f32, n as usize * m as usize ).reshape((n, m));
+    let b = RcArray::eye(m);
     assert_eq!(a.mat_mul(&b), a);
-    let c = Array::eye(n);
+    let c = RcArray::eye(n);
     assert_eq!(c.mat_mul(&a), a);
 }
 
@@ -55,7 +55,7 @@ fn test_mat_mul() {
 #[test]
 fn test_slice()
 {
-    let mut A = Array::<usize, _>::zeros((3, 4));
+    let mut A = RcArray::<usize, _>::zeros((3, 4));
     for (i, elt) in A.iter_mut().enumerate() {
         *elt = i;
     }
@@ -71,14 +71,14 @@ fn test_slice()
 #[test]
 fn slice_oob()
 {
-    let a = Array::<i32, _>::zeros((3, 4));
+    let a = RcArray::<i32, _>::zeros((3, 4));
     let _vi = a.slice(&[Si(0, Some(10), 1), S]);
 }
 
 #[test]
 fn test_index()
 {
-    let mut A = Array::<usize, _>::zeros((2, 3));
+    let mut A = RcArray::<usize, _>::zeros((2, 3));
     for (i, elt) in A.iter_mut().enumerate() {
         *elt = i;
     }
@@ -98,7 +98,7 @@ fn test_index()
 #[test]
 fn test_add()
 {
-    let mut A = Array::<usize, _>::zeros((2, 2));
+    let mut A = RcArray::<usize, _>::zeros((2, 2));
     for (i, elt) in A.iter_mut().enumerate() {
         *elt = i;
     }
@@ -114,7 +114,7 @@ fn test_add()
 #[test]
 fn test_multidim()
 {
-    let mut mat = Array::zeros(2*3*4*5*6).reshape((2,3,4,5,6));
+    let mut mat = RcArray::zeros(2*3*4*5*6).reshape((2,3,4,5,6));
     mat[(0,0,0,0,0)] = 22u8;
     {
         for (i, elt) in mat.iter_mut().enumerate() {
@@ -140,7 +140,7 @@ array([[[ 7,  6],
 #[test]
 fn test_negative_stride_rcarray()
 {
-    let mut mat = Array::zeros((2, 4, 2));
+    let mut mat = RcArray::zeros((2, 4, 2));
     mat[(0, 0, 0)] = 1.0f32;
     for (i, elt) in mat.iter_mut().enumerate() {
         *elt = i as f32;
@@ -167,7 +167,7 @@ fn test_negative_stride_rcarray()
 #[test]
 fn test_cow()
 {
-    let mut mat = Array::<isize, _>::zeros((2,2));
+    let mut mat = RcArray::<isize, _>::zeros((2,2));
     mat[[0, 0]] = 1;
     let n = mat.clone();
     mat[[0, 1]] = 2;
@@ -200,14 +200,14 @@ fn test_cow()
 #[test]
 fn test_sub()
 {
-    let mat = Array::linspace(0., 15., 16).reshape((2, 4, 2));
+    let mat = RcArray::linspace(0., 15., 16).reshape((2, 4, 2));
     let s1 = mat.subview(0,0);
     let s2 = mat.subview(0,1);
     assert_eq!(s1.dim(), (4, 2));
     assert_eq!(s2.dim(), (4, 2));
-    let n = Array::linspace(8., 15., 8).reshape((4,2));
+    let n = RcArray::linspace(8., 15., 8).reshape((4,2));
     assert_eq!(n, s2);
-    let m = Array::from_vec(vec![2., 3., 10., 11.]).reshape((2, 2));
+    let m = RcArray::from_vec(vec![2., 3., 10., 11.]).reshape((2, 2));
     assert_eq!(m, mat.subview(1, 1));
 }
 
@@ -221,7 +221,7 @@ fn diag()
     assert_eq!(d.dim(), 2);
     let d = arr2::<f32, _>(&[[]]).into_diag();
     assert_eq!(d.dim(), 0);
-    let d = Array::<f32, _>::zeros(()).into_diag();
+    let d = RcArray::<f32, _>::zeros(()).into_diag();
     assert_eq!(d.dim(), 1);
 }
 
@@ -263,12 +263,12 @@ fn assign()
     assert_eq!(a, b);
 
     /* Test broadcasting */
-    a.assign(&Array::zeros(1));
-    assert_eq!(a, Array::zeros((2, 2)));
+    a.assign(&RcArray::zeros(1));
+    assert_eq!(a, RcArray::zeros((2, 2)));
 
     /* Test other type */
     a.assign(&OwnedArray::from_elem((2, 2), 3.));
-    assert_eq!(a, Array::from_elem((2, 2), 3.));
+    assert_eq!(a, RcArray::from_elem((2, 2), 3.));
 
     /* Test mut view */
     let mut a = arr2(&[[1, 2], [3, 4]]);
@@ -393,7 +393,7 @@ fn owned_array1() {
     assert_eq!(a.shape(), &[4]);
 
     let mut a = OwnedArray::zeros((2, 2));
-    let mut b = Array::zeros((2, 2));
+    let mut b = RcArray::zeros((2, 2));
     a[(1, 1)] = 3;
     b[(1, 1)] = 3;
     assert_eq!(a, b);
@@ -418,7 +418,7 @@ fn owned_array_with_stride() {
 
 #[test]
 fn views() {
-    let a = Array::from_vec(vec![1, 2, 3, 4]).reshape((2, 2));
+    let a = RcArray::from_vec(vec![1, 2, 3, 4]).reshape((2, 2));
     let b = a.view();
     assert_eq!(a, b);
     assert_eq!(a.shape(), b.shape());
@@ -433,7 +433,7 @@ fn views() {
 
 #[test]
 fn view_mut() {
-    let mut a = Array::from_vec(vec![1, 2, 3, 4]).reshape((2, 2));
+    let mut a = RcArray::from_vec(vec![1, 2, 3, 4]).reshape((2, 2));
     for elt in &mut a.view_mut() {
         *elt = 0;
     }
@@ -447,12 +447,12 @@ fn view_mut() {
     for elt in a.view_mut() {
         *elt = 2;
     }
-    assert_eq!(a, Array::from_elem((2, 2), 2));
+    assert_eq!(a, RcArray::from_elem((2, 2), 2));
 }
 
 #[test]
 fn slice_mut() {
-    let mut a = Array::from_vec(vec![1, 2, 3, 4]).reshape((2, 2));
+    let mut a = RcArray::from_vec(vec![1, 2, 3, 4]).reshape((2, 2));
     for elt in a.slice_mut(&[S, S]) {
         *elt = 0;
     }
@@ -594,8 +594,8 @@ fn arithmetic_broadcast() {
 fn char_array()
 {
     // test compilation & basics of non-numerical array
-    let cc = Array::from_iter("alphabet".chars()).reshape((4, 2));
-    assert!(cc.subview(1, 0) == Array::from_iter("apae".chars()));
+    let cc = RcArray::from_iter("alphabet".chars()).reshape((4, 2));
+    assert!(cc.subview(1, 0) == RcArray::from_iter("apae".chars()));
 }
 
 #[test]

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -1,19 +1,19 @@
 
 extern crate ndarray;
 
-use ndarray::{Array, Dimension};
+use ndarray::{RcArray, Dimension};
 
 #[test]
 fn broadcast_1()
 {
     let a_dim = (2, 4, 2, 2);
     let b_dim = (2, 1, 2, 1);
-    let a = Array::linspace(0., 1., a_dim.size()).reshape(a_dim);
-    let b = Array::linspace(0., 1., b_dim.size()).reshape(b_dim);
+    let a = RcArray::linspace(0., 1., a_dim.size()).reshape(a_dim);
+    let b = RcArray::linspace(0., 1., b_dim.size()).reshape(b_dim);
     assert!(b.broadcast(a.dim()).is_some());
 
     let c_dim = (2, 1);
-    let c = Array::linspace(0., 1., c_dim.size()).reshape(c_dim);
+    let c = RcArray::linspace(0., 1., c_dim.size()).reshape(c_dim);
     assert!(c.broadcast(1).is_none());
     assert!(c.broadcast(()).is_none());
     assert!(c.broadcast((2, 1)).is_some());
@@ -22,7 +22,7 @@ fn broadcast_1()
     assert!(c.broadcast((32, 1, 2)).is_none());
 
     /* () can be broadcast to anything */
-    let z = Array::<f32,_>::zeros(());
+    let z = RcArray::<f32,_>::zeros(());
     assert!(z.broadcast(()).is_some());
     assert!(z.broadcast(1).is_some());
     assert!(z.broadcast(3).is_some());
@@ -34,10 +34,10 @@ fn test_add()
 {
     let a_dim = (2, 4, 2, 2);
     let b_dim = (2, 1, 2, 1);
-    let mut a = Array::linspace(0.0, 1., a_dim.size()).reshape(a_dim);
-    let b = Array::linspace(0.0, 1., b_dim.size()).reshape(b_dim);
+    let mut a = RcArray::linspace(0.0, 1., a_dim.size()).reshape(a_dim);
+    let b = RcArray::linspace(0.0, 1., b_dim.size()).reshape(b_dim);
     a.iadd(&b);
-    let t = Array::from_elem((), 1.0f32);
+    let t = RcArray::from_elem((), 1.0f32);
     a.iadd(&t);
 }
 
@@ -45,7 +45,7 @@ fn test_add()
 fn test_add_incompat()
 {
     let a_dim = (2, 4, 2, 2);
-    let mut a = Array::linspace(0.0, 1., a_dim.size()).reshape(a_dim);
-    let incompat = Array::from_elem(3, 1.0f32);
+    let mut a = RcArray::linspace(0.0, 1., a_dim.size()).reshape(a_dim);
+    let incompat = RcArray::from_elem(3, 1.0f32);
     a.iadd(&incompat);
 }

--- a/tests/complex.rs
+++ b/tests/complex.rs
@@ -3,7 +3,7 @@ extern crate num;
 extern crate ndarray;
 
 use ndarray::{arr1, arr2};
-use ndarray::{Array};
+use ndarray::RcArray;
 use num::{Num, Complex};
 
 fn c<T: Clone + Num>(re: T, im: T) -> Complex<T> {
@@ -16,7 +16,7 @@ fn complex_mat_mul()
     let a = arr2(&[[c(3., 4.), c(2., 0.)], [c(0., -2.), c(3., 0.)]]);
     let b = (&a * c(3., 0.)).map(|c| 5. * c / c.norm());
     println!("{:>8.2}", b);
-    let e = Array::eye(2);
+    let e = RcArray::eye(2);
     let r = a.mat_mul(&e);
     println!("{}", a);
     assert_eq!(r, a);

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -1,7 +1,7 @@
 extern crate ndarray;
 
 use ndarray::{
-    Array,
+    RcArray,
     RemoveAxis,
     arr2,
 };
@@ -16,7 +16,7 @@ fn remove_axis()
     assert_eq!(vec![1,2].remove_axis(0), vec![2]);
     assert_eq!(vec![4, 5, 6].remove_axis(1), vec![4, 6]);
 
-    let a = Array::<f32, _>::zeros(vec![4,5,6]);
+    let a = RcArray::<f32, _>::zeros(vec![4,5,6]);
     let _b = a.into_subview(1, 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
     
 }
@@ -25,14 +25,14 @@ fn remove_axis()
 fn dyn_dimension()
 {
     let a = arr2(&[[1., 2.], [3., 4.0]]).reshape(vec![2, 2]);
-    assert_eq!(&a - &a, Array::zeros(vec![2, 2]));
+    assert_eq!(&a - &a, RcArray::zeros(vec![2, 2]));
     assert_eq!(a[&[0, 0][..]], 1.);
     assert_eq!(a[vec![0, 0]], 1.);
 
     let mut dim = vec![1; 1024];
     dim[16] = 4;
     dim[17] = 3;
-    let z = Array::<f32, _>::zeros(dim.clone());
+    let z = RcArray::<f32, _>::zeros(dim.clone());
     assert_eq!(z.shape(), &dim[..]);
 }
 

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -2,7 +2,7 @@
 extern crate ndarray;
 extern crate itertools;
 
-use ndarray::Array;
+use ndarray::RcArray;
 use ndarray::{Ix, Si, S};
 use ndarray::{
     ArrayBase,
@@ -18,7 +18,7 @@ use itertools::{rev, enumerate};
 
 #[test]
 fn double_ended() {
-    let a = Array::linspace(0., 7., 8);
+    let a = RcArray::linspace(0., 7., 8);
     let mut it = a.iter().map(|x| *x);
     assert_eq!(it.next(), Some(0.));
     assert_eq!(it.next_back(), Some(7.));
@@ -31,7 +31,7 @@ fn double_ended() {
 #[test]
 fn iter_size_hint() {
     // Check that the size hint is correctly computed
-    let a = Array::from_iter(0..24).reshape((2, 3, 4));
+    let a = RcArray::from_iter(0..24).reshape((2, 3, 4));
     let mut data = [0; 24];
     for (i, elt) in enumerate(&mut data) {
         *elt = i as i32;
@@ -49,7 +49,7 @@ fn iter_size_hint() {
 #[test]
 fn indexed()
 {
-    let a = Array::linspace(0., 7., 8);
+    let a = RcArray::linspace(0., 7., 8);
     for (i, elt) in a.indexed_iter() {
         assert_eq!(i, *elt as Ix);
     }
@@ -81,7 +81,7 @@ fn assert_slice_correct<A, S, D>(v: &ArrayBase<S, D>)
 
 #[test]
 fn as_slice() {
-    let a = Array::linspace(0., 7., 8);
+    let a = RcArray::linspace(0., 7., 8);
     let a = a.reshape((2, 4, 1));
 
     assert_slice_correct(&a);
@@ -118,7 +118,7 @@ fn as_slice() {
 
 #[test]
 fn inner_iter() {
-    let a = Array::from_iter(0..12);
+    let a = RcArray::from_iter(0..12);
     let a = a.reshape((2, 3, 2));
     // [[[0, 1],
     //   [2, 3],
@@ -129,7 +129,7 @@ fn inner_iter() {
     assert_equal(a.inner_iter(),
                  vec![aview1(&[0, 1]), aview1(&[2, 3]), aview1(&[4, 5]),
                       aview1(&[6, 7]), aview1(&[8, 9]), aview1(&[10, 11])]);
-    let mut b = Array::zeros((2, 3, 2));
+    let mut b = RcArray::zeros((2, 3, 2));
     b.swap_axes(0, 2);
     b.assign(&a);
     assert_equal(b.inner_iter(),
@@ -139,14 +139,14 @@ fn inner_iter() {
 
 #[test]
 fn inner_iter_corner_cases() {
-    let a0 = Array::zeros(());
+    let a0 = RcArray::zeros(());
     assert_equal(a0.inner_iter(), vec![aview1(&[0])]);
 
-    let a2 = Array::<i32, _>::zeros((0, 3));
+    let a2 = RcArray::<i32, _>::zeros((0, 3));
     assert_equal(a2.inner_iter(),
                  vec![aview1(&[]); 0]);
 
-    let a2 = Array::<i32, _>::zeros((3, 0));
+    let a2 = RcArray::<i32, _>::zeros((3, 0));
     assert_equal(a2.inner_iter(),
                  vec![aview1(&[]); 3]);
 }
@@ -154,7 +154,7 @@ fn inner_iter_corner_cases() {
 #[test]
 fn inner_iter_size_hint() {
     // Check that the size hint is correctly computed
-    let a = Array::from_iter(0..24).reshape((2, 3, 4));
+    let a = RcArray::from_iter(0..24).reshape((2, 3, 4));
     let mut len = 6;
     let mut it = a.inner_iter();
     assert_eq!(it.len(), len);
@@ -167,7 +167,7 @@ fn inner_iter_size_hint() {
 
 #[test]
 fn outer_iter() {
-    let a = Array::from_iter(0..12);
+    let a = RcArray::from_iter(0..12);
     let a = a.reshape((2, 3, 2));
     // [[[0, 1],
     //   [2, 3],
@@ -177,7 +177,7 @@ fn outer_iter() {
     //    ...
     assert_equal(a.outer_iter(),
                  vec![a.subview(0, 0), a.subview(0, 1)]);
-    let mut b = Array::zeros((2, 3, 2));
+    let mut b = RcArray::zeros((2, 3, 2));
     b.swap_axes(0, 2);
     b.assign(&a);
     assert_equal(b.outer_iter(),
@@ -201,7 +201,7 @@ fn outer_iter() {
     assert_eq!(&found_rows, &found_rows_rev);
 
     // Test a case where strides are negative instead
-    let mut c = Array::zeros((2, 3, 2));
+    let mut c = RcArray::zeros((2, 3, 2));
     let mut cv = c.slice_mut(s![..;-1, ..;-1, ..;-1]);
     cv.assign(&a);
     assert_eq!(&a, &cv);
@@ -220,7 +220,7 @@ fn outer_iter() {
 
 #[test]
 fn axis_iter() {
-    let a = Array::from_iter(0..12);
+    let a = RcArray::from_iter(0..12);
     let a = a.reshape((2, 3, 2));
     // [[[0, 1],
     //   [2, 3],
@@ -236,18 +236,18 @@ fn axis_iter() {
 
 #[test]
 fn outer_iter_corner_cases() {
-    let a2 = Array::<i32, _>::zeros((0, 3));
+    let a2 = RcArray::<i32, _>::zeros((0, 3));
     assert_equal(a2.outer_iter(),
                  vec![aview1(&[]); 0]);
 
-    let a2 = Array::<i32, _>::zeros((3, 0));
+    let a2 = RcArray::<i32, _>::zeros((3, 0));
     assert_equal(a2.outer_iter(),
                  vec![aview1(&[]); 3]);
 }
 
 #[test]
 fn outer_iter_mut() {
-    let a = Array::from_iter(0..12);
+    let a = RcArray::from_iter(0..12);
     let a = a.reshape((2, 3, 2));
     // [[[0, 1],
     //   [2, 3],
@@ -255,7 +255,7 @@ fn outer_iter_mut() {
     //  [[6, 7],
     //   [8, 9],
     //    ...
-    let mut b = Array::zeros((2, 3, 2));
+    let mut b = RcArray::zeros((2, 3, 2));
     b.swap_axes(0, 2);
     b.assign(&a);
     assert_equal(b.outer_iter_mut(),
@@ -272,7 +272,7 @@ fn outer_iter_mut() {
 
 #[test]
 fn axis_iter_mut() {
-    let a = Array::from_iter(0..12);
+    let a = RcArray::from_iter(0..12);
     let a = a.reshape((2, 3, 2));
     // [[[0, 1],
     //   [2, 3],
@@ -297,7 +297,7 @@ fn axis_iter_mut() {
 
 #[test]
 fn axis_chunks_iter() {
-    let a = Array::from_iter(0..24);
+    let a = RcArray::from_iter(0..24);
     let a = a.reshape((2, 6, 2));
 
     let it = a.axis_chunks_iter(1, 2);
@@ -306,7 +306,7 @@ fn axis_chunks_iter() {
                       arr3(&[[[4, 5], [6, 7]], [[16, 17], [18, 19]]]),
                       arr3(&[[[8, 9], [10, 11]], [[20, 21], [22, 23]]])]);
 
-    let a = Array::from_iter(0..28);
+    let a = RcArray::from_iter(0..28);
     let a = a.reshape((2, 7, 2));
 
     let it = a.axis_chunks_iter(1, 2);
@@ -337,7 +337,7 @@ fn axis_chunks_iter_corner_cases() {
     // and enable checking if no pointer offseting is out of bounds. However
     // checking the absence of of out of bounds offseting cannot (?) be
     // done automatically, so one has to launch this test in a debugger.
-    let a = Array::<f32, _>::linspace(0., 7., 8).reshape((8, 1));
+    let a = RcArray::<f32, _>::linspace(0., 7., 8).reshape((8, 1));
     let it = a.axis_chunks_iter(0, 4);
     assert_equal(it, vec![a.slice(s![..4, ..]), a.slice(s![4.., ..])]);
     let a = a.slice(s![..;-1,..]);
@@ -349,18 +349,18 @@ fn axis_chunks_iter_corner_cases() {
                       arr2(&[[4.], [3.], [2.]]),
                       arr2(&[[1.], [0.]])]);
 
-    let b = Array::<f32, _>::zeros((8, 2));
+    let b = RcArray::<f32, _>::zeros((8, 2));
     let a = b.slice(s![1..;2,..]);
     let it = a.axis_chunks_iter(0, 8);
     assert_equal(it, vec![a.view()]);
 
     let it = a.axis_chunks_iter(0, 1);
-    assert_equal(it, vec![Array::zeros((1, 2)); 4]);
+    assert_equal(it, vec![RcArray::zeros((1, 2)); 4]);
 }
 
 #[test]
 fn axis_chunks_iter_mut() {
-    let a = Array::from_iter(0..24);
+    let a = RcArray::from_iter(0..24);
     let mut a = a.reshape((2, 6, 2));
 
     let mut it = a.axis_chunks_iter_mut(1, 2);
@@ -372,7 +372,7 @@ fn axis_chunks_iter_mut() {
 #[test]
 fn outer_iter_size_hint() {
     // Check that the size hint is correctly computed
-    let a = Array::from_iter(0..24).reshape((4, 3, 2));
+    let a = RcArray::from_iter(0..24).reshape((4, 3, 2));
     let mut len = 4;
     let mut it = a.outer_iter();
     assert_eq!(it.len(), len);

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -1,7 +1,7 @@
 extern crate ndarray;
 extern crate num as libnum;
 
-use ndarray::Array;
+use ndarray::RcArray;
 use ndarray::{arr0, arr1, arr2};
 
 use std::fmt;
@@ -26,7 +26,7 @@ fn test_oper(op: &str, a: &[f32], b: &[f32], c: &[f32])
 }
 
 fn test_oper_arr<A: Float + fmt::Debug, D: ndarray::Dimension>
-    (op: &str, mut aa: Array<A,D>, bb: Array<A, D>, cc: Array<A, D>)
+    (op: &str, mut aa: RcArray<A,D>, bb: RcArray<A, D>, cc: RcArray<A, D>)
 {
     match op {
         "+" => {
@@ -101,7 +101,7 @@ fn scalar_operations()
 
     {
         let mut x = c.clone();
-        let mut y = Array::zeros((2, 2));
+        let mut y = RcArray::zeros((2, 2));
         x.iadd_scalar(&1.);
         y.assign_scalar(&2.);
         assert_eq!(x, c + arr0(1.));

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -9,7 +9,7 @@ extern crate serde;
 #[cfg(feature = "rustc-serialize")]
 use serialize::json;
 
-use ndarray::{arr0, arr1, arr2, Array, Ix, S, Si};
+use ndarray::{arr0, arr1, arr2, RcArray, Ix, S, Si};
 
 #[cfg(feature = "serde")]
 #[test]
@@ -25,7 +25,7 @@ fn test_serde()
         let serial = serde::json::encode(&a).unwrap();
         println!("Encode {:?} => {:?}", a, serial);
         */
-        //let res = json::decode::<Array<f32, _>>(&serial);
+        //let res = json::decode::<RcArray<f32, _>>(&serial);
         //println!("{:?}", res);
         //assert_eq!(a, res.unwrap());
     }
@@ -38,7 +38,7 @@ fn test_serde()
         /*
         let serial = serde::json::encode(&a).unwrap();
         println!("{:?}", serial);
-        let res = json::decode::<Array<f32, _>>(&serial);
+        let res = json::decode::<RcArray<f32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
         */
@@ -53,7 +53,7 @@ fn serial_many_dim()
         let a = arr0::<f32>(2.72);
         let serial = json::encode(&a).unwrap();
         println!("Encode {:?} => {:?}", a, serial);
-        let res = json::decode::<Array<f32, _>>(&serial);
+        let res = json::decode::<RcArray<f32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
     }
@@ -63,7 +63,7 @@ fn serial_many_dim()
         println!("{:?}", a);
         let serial = json::encode(&a).unwrap();
         println!("{:?}", serial);
-        let res = json::decode::<Array<f32, _>>(&serial);
+        let res = json::decode::<RcArray<f32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
     }
@@ -73,23 +73,23 @@ fn serial_many_dim()
         println!("{:?}", a);
         let serial = json::encode(&a).unwrap();
         println!("{:?}", serial);
-        let res = json::decode::<Array<f32, _>>(&serial);
+        let res = json::decode::<RcArray<f32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
         let text = r##"{"v":1,"dim":[2,3],"data":[3,1,2.2,3.1,4,7]}"##;
-        let b = json::decode::<Array<f32, (Ix, Ix)>>(text);
+        let b = json::decode::<RcArray<f32, (Ix, Ix)>>(text);
         assert_eq!(a, b.unwrap());
     }
 
 
     {
         // Test a sliced array.
-        let mut a = Array::linspace(0., 31., 32).reshape((2, 2, 2, 4));
+        let mut a = RcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
         a.islice(&[Si(0, None, -1), S, S, Si(0, Some(2), 1)]);
         println!("{:?}", a);
         let serial = json::encode(&a).unwrap();
         println!("{:?}", serial);
-        let res = json::decode::<Array<f32, _>>(&serial);
+        let res = json::decode::<RcArray<f32, _>>(&serial);
         println!("{:?}", res);
         assert_eq!(a, res.unwrap());
     }
@@ -101,13 +101,13 @@ fn serial_wrong_count()
 {
     // one element too few
     let text = r##"{"v":1,"dim":[2,3],"data":[3,1,2.2,3.1,4]}"##;
-    let arr = json::decode::<Array<f32, (Ix, Ix)>>(text);
+    let arr = json::decode::<RcArray<f32, (Ix, Ix)>>(text);
     println!("{:?}", arr);
     assert!(arr.is_err());
 
     // future version
     let text = r##"{"v":200,"dim":[2,3],"data":[3,1,2.2,3.1,4,7]}"##;
-    let arr = json::decode::<Array<f32, (Ix, Ix)>>(text);
+    let arr = json::decode::<RcArray<f32, (Ix, Ix)>>(text);
     println!("{:?}", arr);
     assert!(arr.is_err());
 }


### PR DESCRIPTION
This is clearer and makes it sound less like `Array` is the default type
to use.