### PR TITLE
split_at for OuterIter

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -627,7 +627,12 @@ impl<'a, A, D> OuterIterMut<'a, A, D>
         -> (OuterIterMut<'a, A, D>, OuterIterMut<'a, A, D>)
     {
         assert!(index <= self.iter.len);
-        let right_ptr = unsafe { self.iter.offset(index) };
+        let right_ptr = if index != self.iter.len {
+            unsafe { self.iter.offset(index) } 
+        }
+        else {
+            self.iter.ptr
+        };
         let left = OuterIterMut {
             iter: OuterIterCore {
                 index: 0,

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -494,7 +494,12 @@ impl<'a, A, D> OuterIter<'a, A, D>
         -> (OuterIter<'a, A, D>, OuterIter<'a, A, D>)
     {
         assert!(index <= self.iter.len);
-        let right_ptr = unsafe { self.iter.offset(index) };
+        let right_ptr = if index != self.iter.len {
+            unsafe { self.iter.offset(index) } 
+        }
+        else {
+            self.iter.ptr
+        };
         let left = OuterIter {
             iter: OuterIterCore {
                 index: 0,

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -498,7 +498,7 @@ impl<'a, A, D> OuterIter<'a, A, D>
         let left = OuterIter {
             iter: OuterIterCore {
                 index: 0,
-                len: self.iter.index,
+                len: index,
                 stride: self.iter.stride,
                 inner_dim: self.iter.inner_dim.clone(),
                 inner_strides: self.iter.inner_strides.clone(),
@@ -506,7 +506,18 @@ impl<'a, A, D> OuterIter<'a, A, D>
             },
             life: PhantomData,
         };
-        unimplemented!()
+        let right = OuterIter {
+            iter: OuterIterCore {
+                index: 0,
+                len: self.iter.len - index,
+                stride: self.iter.stride,
+                inner_dim: self.iter.inner_dim.clone(),
+                inner_strides: self.iter.inner_strides.clone(),
+                ptr: right_ptr,
+            },
+            life: PhantomData,
+        };
+        (left, right)
     }
 }
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -428,6 +428,12 @@ fn new_outer_core<A, S, D>(v: ArrayBase<S, D>, axis: usize)
     }
 }
 
+impl<A, D> OuterIterCore<A, D> {
+    unsafe fn offset(&self, index: usize) -> *mut A {
+        self.ptr.offset(index as isize * self.stride)
+    }
+}
+
 impl<A, D> Iterator for OuterIterCore<A, D>
     where D: Dimension,
 {
@@ -437,9 +443,7 @@ impl<A, D> Iterator for OuterIterCore<A, D>
         if self.index >= self.len {
             None
         } else {
-            let ptr = unsafe {
-                self.ptr.offset(self.index as isize * self.stride)
-            };
+            let ptr = unsafe { self.offset(self.index) };
             self.index += 1;
             Some(ptr)
         }
@@ -459,9 +463,7 @@ impl<A, D> DoubleEndedIterator for OuterIterCore<A, D>
             None
         } else {
             self.len -= 1;
-            let ptr = unsafe {
-                self.ptr.offset(self.len as isize * self.stride)
-            };
+            let ptr = unsafe { self.offset(self.len) };
             Some(ptr)
         }
     }

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -484,6 +484,32 @@ pub struct OuterIter<'a, A: 'a, D> {
     life: PhantomData<&'a A>,
 }
 
+impl<'a, A, D> OuterIter<'a, A, D>
+    where D: Dimension
+{
+    /// Split the iterator at index
+    ///
+    /// *panics* if `index > len`.
+    pub fn split_at(&self, index: Ix)
+        -> (OuterIter<'a, A, D>, OuterIter<'a, A, D>)
+    {
+        assert!(index <= self.iter.len);
+        let right_ptr = unsafe { self.iter.offset(index) };
+        let left = OuterIter {
+            iter: OuterIterCore {
+                index: 0,
+                len: self.iter.index,
+                stride: self.iter.stride,
+                inner_dim: self.iter.inner_dim.clone(),
+                inner_strides: self.iter.inner_strides.clone(),
+                ptr: self.iter.ptr,
+            },
+            life: PhantomData,
+        };
+        unimplemented!()
+    }
+}
+
 impl<'a, A, D> Iterator for OuterIter<'a, A, D>
     where D: Dimension
 {

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -521,6 +521,24 @@ impl<'a, A, D> OuterIter<'a, A, D>
     }
 }
 
+impl<'a, A, D> Clone for OuterIter<'a, A, D>
+    where D: Dimension
+{
+    fn clone(&self) -> Self {
+        OuterIter {
+            iter: OuterIterCore {
+                index: self.iter.index,
+                len: self.iter.len,
+                stride: self.iter.stride,
+                inner_dim: self.iter.inner_dim.clone(),
+                inner_strides: self.iter.inner_strides.clone(),
+                ptr: self.iter.ptr,
+            },
+            life: PhantomData,
+        }
+    }
+}
+
 impl<'a, A, D> Iterator for OuterIter<'a, A, D>
     where D: Dimension
 {

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -432,3 +432,23 @@ fn outer_iter_split_at_panics() {
     let it = a.outer_iter();
     it.split_at(6);
 }
+
+#[test]
+fn outer_iter_mut_split_at() {
+    let mut a = Array::from_iter(0..30).reshape((5, 3, 2));
+
+    {
+        let it = a.outer_iter_mut();
+        let (mut itl, mut itr) = it.split_at(2);
+        itl.next();
+        itl.next().unwrap()[[2, 1]] += 1; // now this value is 12
+        assert_eq!(itl.next(), None);
+
+        itr.next();
+        itr.next();
+        itr.next().unwrap()[[2, 1]] -= 1; // now this value is 28
+        assert_eq!(itr.next(), None);
+    }
+    assert_eq!(a[[1, 2, 1]], 12);
+    assert_eq!(a[[4, 2, 1]], 28);
+}

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -407,7 +407,7 @@ fn outer_iter_split_at() {
     let a = Array::from_iter(0..30).reshape((5, 3, 2));
 
     let it = a.outer_iter();
-    let (mut itl, mut itr) = it.split_at(2);
+    let (mut itl, mut itr) = it.clone().split_at(2);
     assert_eq!(itl.next().unwrap()[[2, 1]], 5);
     assert_eq!(itl.next().unwrap()[[2, 1]], 11);
     assert_eq!(itl.next(), None);
@@ -419,7 +419,6 @@ fn outer_iter_split_at() {
 
     // split_at on length should yield an empty iterator
     // on the right part
-    let it = a.outer_iter();
     let (_, mut itr) = it.split_at(5);
     assert_eq!(itr.next(), None);
 }

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -404,7 +404,7 @@ fn outer_iter_size_hint() {
 
 #[test]
 fn outer_iter_split_at() {
-    let a = Array::from_iter(0..30).reshape((5, 3, 2));
+    let a = RcArray::from_iter(0..30).reshape((5, 3, 2));
 
     let it = a.outer_iter();
     let (mut itl, mut itr) = it.clone().split_at(2);
@@ -426,7 +426,7 @@ fn outer_iter_split_at() {
 #[test]
 #[should_panic]
 fn outer_iter_split_at_panics() {
-    let a = Array::from_iter(0..30).reshape((5, 3, 2));
+    let a = RcArray::from_iter(0..30).reshape((5, 3, 2));
 
     let it = a.outer_iter();
     it.split_at(6);
@@ -434,7 +434,7 @@ fn outer_iter_split_at_panics() {
 
 #[test]
 fn outer_iter_mut_split_at() {
-    let mut a = Array::from_iter(0..30).reshape((5, 3, 2));
+    let mut a = RcArray::from_iter(0..30).reshape((5, 3, 2));
 
     {
         let it = a.outer_iter_mut();

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -401,3 +401,34 @@ fn outer_iter_size_hint() {
         assert_eq!(it.len(), len);
     }
 }
+
+#[test]
+fn outer_iter_split_at() {
+    let a = Array::from_iter(0..30).reshape((5, 3, 2));
+
+    let it = a.outer_iter();
+    let (mut itl, mut itr) = it.split_at(2);
+    assert_eq!(itl.next().unwrap()[[2, 1]], 5);
+    assert_eq!(itl.next().unwrap()[[2, 1]], 11);
+    assert_eq!(itl.next(), None);
+
+    assert_eq!(itr.next().unwrap()[[2, 1]], 17);
+    assert_eq!(itr.next().unwrap()[[2, 1]], 23);
+    assert_eq!(itr.next().unwrap()[[2, 1]], 29);
+    assert_eq!(itr.next(), None);
+
+    // split_at on length should yield an empty iterator
+    // on the right part
+    let it = a.outer_iter();
+    let (_, mut itr) = it.split_at(5);
+    assert_eq!(itr.next(), None);
+}
+
+#[test]
+#[should_panic]
+fn outer_iter_split_at_panics() {
+    let a = Array::from_iter(0..30).reshape((5, 3, 2));
+
+    let it = a.outer_iter();
+    it.split_at(6);
+}


### PR DESCRIPTION
This PR implements `split_at` for `OuterIter` (see #81). It's still a work in progress as there is one API point I'm not sure about. The current implementation panics if the split index is out of bounds, but there is an alternative: the returned left iterator could be the same as the original iterator, and the right iterator would immediately return `None`.

Also the method needs documentation but it'll wait until the precedent point is decided.