### PR TITLE
Add a scalar trait for specializable scalars

### DIFF
--- a/examples/linalg.rs
+++ b/examples/linalg.rs
@@ -13,6 +13,7 @@ use std::ops::{Add, Sub, Mul, Div};
 
 use ndarray::{RcArray, Ix};
 use ndarray::{rcarr1, rcarr2};
+use ndarray::LinalgScalar;
 
 /// Column vector.
 pub type Col<A> = RcArray<A, Ix>;
@@ -29,7 +30,7 @@ pub trait Field : Ring + Div<Output=Self> { }
 impl<A: Ring + Div<Output=A>> Field for A { }
 
 /// A real or complex number.
-pub trait ComplexField : Copy + Field
+pub trait ComplexField : LinalgScalar
 {
     #[inline]
     fn conjugate(self) -> Self { self }
@@ -50,7 +51,7 @@ impl ComplexField for f64
     fn sqrt_real(self) -> f64 { self.sqrt() }
 }
 
-impl<A: Num + Float> ComplexField for Complex<A>
+impl<A: LinalgScalar + Float +  Num> ComplexField for Complex<A>
 {
     #[inline]
     fn conjugate(self) -> Complex<A> { self.conj() }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2609,7 +2609,7 @@ impl<'a, A, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for &'a ArrayBase<S, D>
     fn $mth (self, rhs: &'a ArrayBase<S2, E>) -> OwnedArray<A, D>
     {
         // FIXME: Can we co-broadcast arrays here? And how?
-        self.to_owned().$mth(rhs.view())
+        self.to_owned().$mth(rhs)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,10 +97,8 @@ pub use iterators::{
     AxisChunksIterMut,
 };
 
-#[allow(deprecated)]
-use linalg::{Field, Ring};
+pub use linalg::LinalgScalar;
 
-pub mod linalg;
 mod arraytraits;
 #[cfg(feature = "serde")]
 mod arrayserialize;
@@ -110,6 +108,7 @@ pub mod blas;
 mod dimension;
 mod indexes;
 mod iterators;
+mod linalg;
 mod linspace;
 mod numeric_util;
 mod si;
@@ -2252,7 +2251,7 @@ impl<A, S, D> ArrayBase<S, D>
     /// **Panics** if `axis` is out of bounds.
     #[allow(deprecated)]
     pub fn mean(&self, axis: usize) -> OwnedArray<A, <D as RemoveAxis>::Smaller>
-        where A: Copy + Field,
+        where A: LinalgScalar,
               D: RemoveAxis,
     {
         let n = self.shape()[axis];
@@ -2289,7 +2288,7 @@ impl<A, S> ArrayBase<S, Ix>
     /// **Panics** if the arrays are not of the same length.
     pub fn dot<S2>(&self, rhs: &ArrayBase<S2, Ix>) -> A
         where S2: Data<Elem=A>,
-              A: Clone + Add<Output=A> + Mul<Output=A> + libnum::Zero,
+              A: LinalgScalar,
     {
         assert_eq!(self.len(), rhs.len());
         if let Some(self_s) = self.as_slice() {
@@ -2369,7 +2368,7 @@ impl<A, S> ArrayBase<S, (Ix, Ix)>
     ///
     #[allow(deprecated)]
     pub fn mat_mul(&self, rhs: &ArrayBase<S, (Ix, Ix)>) -> OwnedArray<A, (Ix, Ix)>
-        where A: Copy + Ring
+        where A: LinalgScalar,
     {
         // NOTE: Matrix multiplication only defined for Copy types to
         // avoid trouble with panicking + and *, and destructors
@@ -2414,7 +2413,7 @@ impl<A, S> ArrayBase<S, (Ix, Ix)>
     /// **Panics** if shapes are incompatible.
     #[allow(deprecated)]
     pub fn mat_mul_col(&self, rhs: &ArrayBase<S, Ix>) -> OwnedArray<A, Ix>
-        where A: Copy + Ring
+        where A: LinalgScalar,
     {
         let ((m, a), n) = (self.dim, rhs.dim);
         let (self_columns, other_rows) = (a, n);

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -1,18 +1,28 @@
-#![allow(non_snake_case, deprecated)]
-#![cfg_attr(has_deprecated, deprecated(note="`linalg` is not in good shape."))]
-
-//! ***Deprecated: linalg is not in good shape.***
-//!
-//! A few linear algebra operations on two-dimensional arrays.
-
-use libnum::{Zero, One};
+use libnum::{Zero, One, Float};
 use std::ops::{Add, Sub, Mul, Div};
+use std::any::Any;
 
-/// Trait union for a ring with 1.
-pub trait Ring : Clone + Zero + Add<Output=Self> + Sub<Output=Self>
-    + One + Mul<Output=Self> { }
-impl<A: Clone + Zero + Add<Output=A> + Sub<Output=A> + One + Mul<Output=A>> Ring for A { }
+/// Trait union for scalars (array elements) that support linear algebra operations.
+///
+/// `Any` for type-based specialization, `Copy` so that they don't need move
+/// semantics or destructors, and the rest are numerical traits.
+pub trait LinalgScalar :
+    Any +
+    Copy +
+    Zero + One +
+    Add<Output=Self> +
+    Sub<Output=Self> +
+    Mul<Output=Self> +
+    Div<Output=Self>
+{ }
 
-/// Trait union for a field.
-pub trait Field : Ring + Div<Output=Self> { }
-impl<A: Ring + Div<Output = A>> Field for A {}
+impl<T> LinalgScalar for T
+    where T:
+    Any +
+    Copy +
+    Zero + One +
+    Add<Output=T> +
+    Sub<Output=T> +
+    Mul<Output=T> +
+    Div<Output=T>
+{ }


### PR DESCRIPTION
- Until rust has specialization, we need `Any` where we want to dispatch for type specialization.

- Remove deprecated (already mostly empty) module `linalg`

- This reduces the number of types we can matrix multiply (as well as operations dot and mean); in return, we can specialize for f32, f64 and other scalar types that linear algebra libraries support.
