### PR TITLE
Use BLAS acceleration in .dot() when possible

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -398,6 +398,16 @@ fn muladd_2d_f32_blas(bench: &mut test::Bencher)
     });
 }
 
+#[bench]
+fn dot_f32_regular(bench: &mut test::Bencher)
+{
+    let av = OwnedArray::<f32, _>::zeros(1024);
+    let bv = OwnedArray::<f32, _>::zeros(1024);
+    bench.iter(|| {
+        av.dot(&bv)
+    });
+}
+
 
 #[bench]
 fn assign_scalar_2d_large(bench: &mut test::Bencher)

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -12,7 +12,6 @@ use rblas::matrix::Matrix;
 
 use ndarray::{
     OwnedArray,
-    zeros,
 };
 use ndarray::{arr0, arr1, arr2};
 
@@ -516,14 +515,14 @@ fn create_iter_4d(bench: &mut test::Bencher)
 #[bench]
 fn bench_to_owned_n(bench: &mut test::Bencher)
 {
-    let a = zeros::<f32, _>((32, 32));
+    let a = OwnedArray::<f32, _>::zeros((32, 32));
     bench.iter(|| a.to_owned());
 }
 
 #[bench]
 fn bench_to_owned_t(bench: &mut test::Bencher)
 {
-    let mut a = zeros::<f32, _>((32, 32));
+    let mut a = OwnedArray::<f32, _>::zeros((32, 32));
     a.swap_axes(0, 1);
     bench.iter(|| a.to_owned());
 }

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -398,17 +398,6 @@ fn muladd_2d_f32_blas(bench: &mut test::Bencher)
 }
 
 #[bench]
-fn dot_f32_regular(bench: &mut test::Bencher)
-{
-    let av = OwnedArray::<f32, _>::zeros(1024);
-    let bv = OwnedArray::<f32, _>::zeros(1024);
-    bench.iter(|| {
-        av.dot(&bv)
-    });
-}
-
-
-#[bench]
 fn assign_scalar_2d_large(bench: &mut test::Bencher)
 {
     let a = OwnedArray::zeros((64, 64));
@@ -544,11 +533,29 @@ fn equality_f32(bench: &mut test::Bencher)
 }
 
 #[bench]
-fn dot(bench: &mut test::Bencher)
+fn dot_f32_16(bench: &mut test::Bencher)
+{
+    let a = OwnedArray::<f32, _>::zeros(16);
+    let b = OwnedArray::<f32, _>::zeros(16);
+    bench.iter(|| a.dot(&b));
+}
+
+#[bench]
+fn dot_f32_256(bench: &mut test::Bencher)
 {
     let a = OwnedArray::<f32, _>::zeros(256);
     let b = OwnedArray::<f32, _>::zeros(256);
     bench.iter(|| a.dot(&b));
+}
+
+#[bench]
+fn dot_f32_1024(bench: &mut test::Bencher)
+{
+    let av = OwnedArray::<f32, _>::zeros(1024);
+    let bv = OwnedArray::<f32, _>::zeros(1024);
+    bench.iter(|| {
+        av.dot(&bv)
+    });
 }
 
 #[bench]

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -48,11 +48,10 @@
 //! I know), instead output its own error conditions, for example on dimension
 //! mismatch in a matrix multiplication.
 //!
-extern crate rblas;
 
 use std::os::raw::{c_int};
 
-use self::rblas::{
+use rblas::{
     Matrix,
     Vector,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2011,7 +2011,10 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     }
 }
 
+/// ***Deprecated: Use `ArrayBase::zeros` instead.***
+///
 /// Return an array filled with zeros
+#[cfg_attr(has_deprecated, deprecated(note="Use `ArrayBase::zeros` instead."))]
 pub fn zeros<A, D>(dim: D) -> OwnedArray<A, D>
     where A: Clone + libnum::Zero, D: Dimension,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2310,12 +2310,11 @@ impl<A, S> ArrayBase<S, Ix>
     /// of complex operands, and thus not their inner product).
     ///
     /// **Panics** if the arrays are not of the same length.
-    #[cfg(not(feature="rblas"))]
     pub fn dot<S2>(&self, rhs: &ArrayBase<S2, Ix>) -> A
         where S2: Data<Elem=A>,
               A: LinalgScalar,
     {
-        self.dot_generic(rhs)
+        self.dot_impl(rhs)
     }
 
     fn dot_generic<S2>(&self, rhs: &ArrayBase<S2, Ix>) -> A
@@ -2337,14 +2336,16 @@ impl<A, S> ArrayBase<S, Ix>
         sum
     }
 
+    #[cfg(not(feature="rblas"))]
+    fn dot_impl<S2>(&self, rhs: &ArrayBase<S2, Ix>) -> A
+        where S2: Data<Elem=A>,
+              A: LinalgScalar,
+    {
+        self.dot_generic(rhs)
+    }
+
     #[cfg(feature="rblas")]
-    /// Compute the dot product of one-dimensional arrays.
-    ///
-    /// The dot product is a sum of the elementwise products (no conjugation
-    /// of complex operands, and thus not their inner product).
-    ///
-    /// **Panics** if the arrays are not of the same length.
-    pub fn dot<S2>(&self, rhs: &ArrayBase<S2, Ix>) -> A
+    fn dot_impl<S2>(&self, rhs: &ArrayBase<S2, Ix>) -> A
         where S2: Data<Elem=A>,
               A: LinalgScalar,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2361,17 +2361,20 @@ impl<A, S> ArrayBase<S, Ix>
                 ::std::ptr::read(a as *const _ as *const B)
             }
         }
-        assert_eq!(self.len(), rhs.len());
-        if let Ok(self_v) = self.blas_view_as_type::<f32>() {
-            if let Ok(rhs_v) = rhs.blas_view_as_type::<f32>() {
-                let f_ret = f32::dot(&self_v, &rhs_v);
-                return cast_as::<f32, A>(&f_ret);
+        // Use only if the vector is large enough to be worth it
+        if self.len() >= 32 {
+            assert_eq!(self.len(), rhs.len());
+            if let Ok(self_v) = self.blas_view_as_type::<f32>() {
+                if let Ok(rhs_v) = rhs.blas_view_as_type::<f32>() {
+                    let f_ret = f32::dot(&self_v, &rhs_v);
+                    return cast_as::<f32, A>(&f_ret);
+                }
             }
-        }
-        if let Ok(self_v) = self.blas_view_as_type::<f64>() {
-            if let Ok(rhs_v) = rhs.blas_view_as_type::<f64>() {
-                let f_ret = f64::dot(&self_v, &rhs_v);
-                return cast_as::<f64, A>(&f_ret);
+            if let Ok(self_v) = self.blas_view_as_type::<f64>() {
+                if let Ok(rhs_v) = rhs.blas_view_as_type::<f64>() {
+                    let f_ret = f64::dot(&self_v, &rhs_v);
+                    return cast_as::<f64, A>(&f_ret);
+                }
             }
         }
         self.dot_generic(rhs)

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -1,6 +1,18 @@
-use libnum::{Zero, One, Float};
+use libnum::{Zero, One};
 use std::ops::{Add, Sub, Mul, Div};
 use std::any::Any;
+
+#[cfg(feature="rblas")]
+use std::any::TypeId;
+
+#[cfg(feature="rblas")]
+use ShapeError;
+
+#[cfg(feature="rblas")]
+use blas::{AsBlas, BlasArrayView};
+
+#[cfg(feature="rblas")]
+use imp_prelude::*;
 
 /// Trait union for scalars (array elements) that support linear algebra operations.
 ///
@@ -26,3 +38,31 @@ impl<T> LinalgScalar for T
     Mul<Output=T> +
     Div<Output=T>
 { }
+
+#[cfg(feature = "rblas")]
+pub trait AsBlasAny<A, S, D> : AsBlas<A, S, D> {
+    fn blas_view_as_type<T: Any>(&self) -> Result<BlasArrayView<T, D>, ShapeError>
+        where S: Data;
+}
+
+#[cfg(feature = "rblas")]
+/// ***Requires `features = "rblas"`***
+impl<A, S, D> AsBlasAny<A, S, D> for ArrayBase<S, D>
+    where S: Data<Elem=A>,
+          D: Dimension,
+          A: Any,
+{
+    fn blas_view_as_type<T: Any>(&self) -> Result<BlasArrayView<T, D>, ShapeError>
+        where S: Data
+    {
+        if TypeId::of::<A>() == TypeId::of::<T>() {
+            unsafe {
+                let v = self.view();
+                let u = ArrayView::new_(v.ptr as *const T, v.dim, v.strides);
+                Priv(u).into_blas_view()
+            }
+        } else {
+            Err(ShapeError::IncompatibleLayout)
+        }
+    }
+}

--- a/src/numeric_util.rs
+++ b/src/numeric_util.rs
@@ -3,8 +3,9 @@ use libnum;
 use std::cmp;
 use std::ops::{
     Add,
-    Mul,
 };
+
+use linalg::LinalgScalar;
 
 /// Compute the sum of the values in `xs`
 pub fn unrolled_sum<A>(mut xs: &[A]) -> A
@@ -44,7 +45,7 @@ pub fn unrolled_sum<A>(mut xs: &[A]) -> A
 ///
 /// `xs` and `ys` must be the same length
 pub fn unrolled_dot<A>(xs: &[A], ys: &[A]) -> A
-    where A: Clone + Add<Output=A> + Mul<Output=A> + libnum::Zero,
+    where A: LinalgScalar,
 {
     debug_assert_eq!(xs.len(), ys.len());
     // eightfold unrolled so that floating point can be vectorized
@@ -58,24 +59,24 @@ pub fn unrolled_dot<A>(xs: &[A], ys: &[A]) -> A
         (A::zero(), A::zero(), A::zero(), A::zero(),
          A::zero(), A::zero(), A::zero(), A::zero());
     while xs.len() >= 8 {
-        p0 = p0 + xs[0].clone() * ys[0].clone();
-        p1 = p1 + xs[1].clone() * ys[1].clone();
-        p2 = p2 + xs[2].clone() * ys[2].clone();
-        p3 = p3 + xs[3].clone() * ys[3].clone();
-        p4 = p4 + xs[4].clone() * ys[4].clone();
-        p5 = p5 + xs[5].clone() * ys[5].clone();
-        p6 = p6 + xs[6].clone() * ys[6].clone();
-        p7 = p7 + xs[7].clone() * ys[7].clone();
+        p0 = p0 + xs[0] * ys[0];
+        p1 = p1 + xs[1] * ys[1];
+        p2 = p2 + xs[2] * ys[2];
+        p3 = p3 + xs[3] * ys[3];
+        p4 = p4 + xs[4] * ys[4];
+        p5 = p5 + xs[5] * ys[5];
+        p6 = p6 + xs[6] * ys[6];
+        p7 = p7 + xs[7] * ys[7];
 
         xs = &xs[8..];
         ys = &ys[8..];
     }
-    sum = sum.clone() + (p0 + p4);
-    sum = sum.clone() + (p1 + p5);
-    sum = sum.clone() + (p2 + p6);
-    sum = sum.clone() + (p3 + p7);
+    sum = sum + (p0 + p4);
+    sum = sum + (p1 + p5);
+    sum = sum + (p2 + p6);
+    sum = sum + (p3 + p7);
     for i in 0..xs.len() {
-        sum = sum.clone() + xs[i].clone() * ys[i].clone();
+        sum = sum + xs[i] * ys[i];
     }
     sum
 }

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -3,6 +3,9 @@ extern crate num as libnum;
 
 use ndarray::RcArray;
 use ndarray::{arr0, rcarr1, rcarr2};
+use ndarray::{
+    OwnedArray,
+};
 
 use std::fmt;
 use libnum::Float;
@@ -107,4 +110,24 @@ fn scalar_operations()
         assert_eq!(x, c + arr0(1.));
         assert_eq!(x, y);
     }
+}
+
+fn assert_approx_eq<F: fmt::Debug + Float>(f: F, g: F, tol: F) -> bool {
+    assert!((f - g).abs() <= tol, "{:?} approx== {:?} (tol={:?})",
+            f, g, tol);
+    true
+}
+
+#[test]
+fn dot_product() {
+    let a = OwnedArray::linspace(0., 63., 64);
+    let b = OwnedArray::linspace(0., 63., 64);
+    let dot = 85344.;
+    assert_approx_eq(a.dot(&b), dot, 1e-5);
+    let a = a.map(|f| *f as f32);
+    let b = a.map(|f| *f as f32);
+    assert_approx_eq(a.dot(&b), dot as f32, 1e-5);
+    let a = a.map(|f| *f as i32);
+    let b = a.map(|f| *f as i32);
+    assert_eq!(a.dot(&b), dot as i32);
 }


### PR DESCRIPTION
Use BLAS to compute the dot product when possible (for f32 and f64).

Even though our manual scalar product implementation is pretty good, the BLAS implementation still manages to beat it and finish the 1024 element dot product twice as fast. So this is an improvement even in the simplest kinds of cases. (But we still use the generic dot for vectors shorter than 32 elements, since that is faster).

- Introduce an internal module `imp_prelude` (implementation's prelude) that simplifies importing the main types that we use everywhere.
- Add type `Priv` that can be used to attach private methods that can still be used everywhere in the crate.
- Deprecate ArrayBase::zeros (stray extra change).