### PR TITLE
Arithmetic operations B @ A are now only implemented for owned storage `B`

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -266,7 +266,7 @@ fn add_2d_regular(bench: &mut test::Bencher)
     let b = OwnedArray::<i32, _>::zeros((64, 64));
     let bv = b.view();
     bench.iter(|| {
-        let _x = black_box(a.view_mut() + bv);
+        a.iadd(&bv);
     });
 }
 
@@ -292,7 +292,7 @@ fn add_2d_cutout(bench: &mut test::Bencher)
     let b = OwnedArray::<i32, _>::zeros((64, 64));
     let bv = b.view();
     bench.iter(|| {
-        let _x = black_box(acut.view_mut() + bv);
+        acut.iadd(&bv);
     });
 }
 
@@ -303,7 +303,7 @@ fn add_2d_broadcast_1_to_2(bench: &mut test::Bencher)
     let b = OwnedArray::<i32, _>::zeros(64);
     let bv = b.view();
     bench.iter(|| {
-        let _x = black_box(a.view_mut() + bv);
+        a.iadd(&bv);
     });
 }
 
@@ -314,7 +314,7 @@ fn add_2d_broadcast_0_to_2(bench: &mut test::Bencher)
     let b = OwnedArray::<i32, _>::zeros(());
     let bv = b.view();
     bench.iter(|| {
-        let _x = black_box(a.view_mut() + bv);
+        a.iadd(&bv);
     });
 }
 
@@ -337,7 +337,7 @@ fn add_2d_transposed(bench: &mut test::Bencher)
     let b = OwnedArray::<i32, _>::zeros((64, 64));
     let bv = b.view();
     bench.iter(|| {
-        let _x = black_box(a.view_mut() + bv);
+        a.iadd(&bv);
     });
 }
 
@@ -348,7 +348,7 @@ fn add_2d_f32_regular(bench: &mut test::Bencher)
     let b = OwnedArray::<f32, _>::zeros((64, 64));
     let bv = b.view();
     bench.iter(|| {
-        let _x = black_box(a.view_mut() + bv);
+        a.iadd(&bv);
     });
 }
 

--- a/examples/life.rs
+++ b/examples/life.rs
@@ -40,17 +40,16 @@ fn iterate(z: &mut Board, scratch: &mut Board) {
     // compute number of neighbors
     let mut neigh = scratch.view_mut();
     neigh.assign_scalar(&0);
-    let neigh = neigh
-    + z.slice(s![0..-2, 0..-2])
-    + z.slice(s![0..-2, 1..-1])
-    + z.slice(s![0..-2, 2..  ])
+    neigh.iadd(&z.slice(s![0..-2, 0..-2]));
+    neigh.iadd(&z.slice(s![0..-2, 1..-1]));
+    neigh.iadd(&z.slice(s![0..-2, 2..  ]));
 
-    + z.slice(s![1..-1, 0..-2])
-    + z.slice(s![1..-1, 2..  ])
+    neigh.iadd(&z.slice(s![1..-1, 0..-2]));
+    neigh.iadd(&z.slice(s![1..-1, 2..  ]));
 
-    + z.slice(s![2..  , 0..-2])
-    + z.slice(s![2..  , 1..-1])
-    + z.slice(s![2..  , 2..  ]);
+    neigh.iadd(&z.slice(s![2..  , 0..-2]));
+    neigh.iadd(&z.slice(s![2..  , 1..-1]));
+    neigh.iadd(&z.slice(s![2..  , 2..  ]));
 
     // birth where n = 3 and z[i] = 0,
     // survive where n = 2 || n = 3 and z[i] = 1

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -185,7 +185,7 @@ unsafe impl<S, D> Send for ArrayBase<S, D>
 // Use version number so we can add a packed format later.
 static ARRAY_FORMAT_VERSION: u8 = 1u8;
 
-/// **Requires `feature = "rustc-serialize"`**
+/// **Requires crate feature `"rustc-serialize"`**
 #[cfg(feature = "rustc-serialize")]
 impl<A, S, D> Encodable for ArrayBase<S, D>
     where A: Encodable,
@@ -212,7 +212,7 @@ impl<A, S, D> Encodable for ArrayBase<S, D>
     }
 }
 
-/// **Requires `feature = "rustc-serialize"`**
+/// **Requires crate feature `"rustc-serialize"`**
 #[cfg(feature = "rustc-serialize")]
 impl<A, S, D> Decodable for ArrayBase<S, D>
     where A: Decodable,

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -1,6 +1,6 @@
 //! Experimental BLAS (Basic Linear Algebra Subprograms) integration
 //!
-//! ***Requires `features = "rblas"`***
+//! ***Requires crate feature `"rblas"`***
 //!
 //! Depends on crate [`rblas`], ([docs]).
 //!
@@ -70,7 +70,7 @@ use super::{
 };
 
 
-/// ***Requires `features = "rblas"`***
+/// ***Requires crate feature `"rblas"`***
 pub struct BlasArrayView<'a, A: 'a, D>(ArrayView<'a, A, D>);
 impl<'a, A, D: Copy> Copy for BlasArrayView<'a, A, D> { }
 impl<'a, A, D: Clone> Clone for BlasArrayView<'a, A, D> {
@@ -79,7 +79,7 @@ impl<'a, A, D: Clone> Clone for BlasArrayView<'a, A, D> {
     }
 }
 
-/// ***Requires `features = "rblas"`***
+/// ***Requires crate feature `"rblas"`***
 pub struct BlasArrayViewMut<'a, A: 'a, D>(ArrayViewMut<'a, A, D>);
 
 impl<S, D> ArrayBase<S, D>
@@ -137,7 +137,7 @@ impl<'a, A, D> ArrayViewMut<'a, A, D>
 /// Note that `blas` suppors four different element types: `f32`, `f64`,
 /// `Complex<f32>`, and `Complex<f64>`.
 ///
-/// ***Requires `features = "rblas"`***
+/// ***Requires crate feature `"rblas"`***
 pub trait AsBlas<A, S, D> {
     /// Return an array view implementing Vector (1D) or Matrix (2D)
     /// traits.
@@ -222,7 +222,7 @@ pub trait AsBlas<A, S, D> {
         */
 }
 
-/// ***Requires `features = "rblas"`***
+/// ***Requires crate feature `"rblas"`***
 impl<A, S, D> AsBlas<A, S, D> for ArrayBase<S, D>
     where S: Data<Elem=A>,
           D: Dimension,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,16 @@ pub type Ixs = isize;
 /// [`ArrayView`]: type.ArrayView.html
 /// [`ArrayViewMut`]: type.ArrayViewMut.html
 ///
+/// ## Contents
+///
+/// + [OwnedArray and RcArray](#ownedarray-and-rcarray)
+/// + [Indexing and Dimension](#indexing-and-dimension)
+/// + [Slicing](#slicing)
+/// + [Subviews](#subviews)
+/// + [Arithmetic Operations](#arithmetic-operations)
+/// + [Broadcasting](#broadcasting)
+/// + [Methods](#methods)
+///
 /// ## `OwnedArray` and `RcArray`
 ///
 /// `OwnedArray` owns the underlying array elements directly (just like

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@
 //!
 //! ## Crate Feature Flags
 //!
+//! The following crate feature flags are available. The are specified in
+//! `Cargo.toml`.
+//!
 //! - `assign_ops`
 //!   - Optional, requires nightly
 //!   - Enables the compound assignment operators
@@ -317,7 +320,7 @@ pub type Ixs = isize;
 /// - `B @ A` which consumes `B`, updates it with the result, and returns it
 /// - `B @ &A` which consumes `B`, updates it with the result, and returns it
 /// - `C @= &A` which performs an arithmetic operation in place
-///   (requires `features = "assign_ops"`)
+///   (requires crate feature `"assign_ops"`)
 ///
 /// The trait [`Scalar`](trait.Scalar.html) marks types that can be used in arithmetic
 /// with arrays directly. For a scalar `K` the following combinations of operands
@@ -326,7 +329,7 @@ pub type Ixs = isize;
 /// - `&A @ K` or `K @ &A` which produces a new `OwnedArray`
 /// - `B @ K` or `K @ B` which consumes `B`, updates it with the result and returns it
 /// - `C @= K` which performs an arithmetic operation in place
-///   (requires `features = "assign_ops"`)
+///   (requires crate feature `"assign_ops"`)
 ///
 /// ## Broadcasting
 ///
@@ -2809,7 +2812,7 @@ mod assign_ops {
     ///
     /// **Panics** if broadcasting isn’t possible.
     ///
-    /// **Requires `feature = "assign_ops"`**
+    /// **Requires crate feature `"assign_ops"`**
     impl<'a, A, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for ArrayBase<S, D>
         where A: Clone + $trt<A>,
               S: DataMut<Elem=A>,
@@ -2825,7 +2828,7 @@ mod assign_ops {
     }
 
     #[doc=$doc]
-    /// **Requires `feature = "assign_ops"`**
+    /// **Requires crate feature `"assign_ops"`**
     impl<A, S, D, B> $trt<B> for ArrayBase<S, D>
         where A: $trt<B>,
               S: DataMut<Elem=A>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,15 +296,17 @@ pub type Ixs = isize;
 ///
 /// Since the trait implementations are hard to overview, here is a summary.
 ///
-/// Let `A` be an array or view of any kind. Let `B` be a mutable
-/// array (that is, either `OwnedArray`, `RcArray`, or `ArrayViewMut`)
+/// Let `A` be an array or view of any kind. Let `B` be an array
+/// with owned storage (either `OwnedArray` or `RcArray`).
+/// Let `C` be an array with mutable data (either `OwnedArray`, `RcArray`
+/// or `ArrayViewMut`).
 /// The following combinations of operands
 /// are supported for an arbitrary binary operator denoted by `@`.
 ///
 /// - `&A @ &A` which produces a new `OwnedArray`
 /// - `B @ A` which consumes `B`, updates it with the result, and returns it
 /// - `B @ &A` which consumes `B`, updates it with the result, and returns it
-/// - `B @= &A` which performs an arithmetic operation in place
+/// - `C @= &A` which performs an arithmetic operation in place
 ///   (requires `features = "assign_ops"`)
 ///
 /// The trait [`Scalar`](trait.Scalar.html) marks types that can be used in arithmetic
@@ -313,7 +315,7 @@ pub type Ixs = isize;
 ///
 /// - `&A @ K` or `K @ &A` which produces a new `OwnedArray`
 /// - `B @ K` or `K @ B` which consumes `B`, updates it with the result and returns it
-/// - `B @= K` which performs an arithmetic operation in place
+/// - `C @= K` which performs an arithmetic operation in place
 ///   (requires `features = "assign_ops"`)
 ///
 /// ## Broadcasting
@@ -2549,12 +2551,14 @@ macro_rules! impl_binary_op(
 /// between `self` and `rhs`,
 /// and return the result (based on `self`).
 ///
+/// `self` must be an `OwnedArray` or `RcArray`.
+///
 /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
 ///
 /// **Panics** if broadcasting isn’t possible.
 impl<A, S, S2, D, E> $trt<ArrayBase<S2, E>> for ArrayBase<S, D>
     where A: Clone + $trt<A, Output=A>,
-          S: DataMut<Elem=A>,
+          S: DataOwned<Elem=A> + DataMut,
           S2: Data<Elem=A>,
           D: Dimension,
           E: Dimension,
@@ -2616,9 +2620,11 @@ impl<'a, A, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for &'a ArrayBase<S, D>
 #[doc=$doc]
 /// between `self` and the scalar `x`,
 /// and return the result (based on `self`).
+///
+/// `self` must be an `OwnedArray` or `RcArray`.
 impl<A, S, D, B> $trt<B> for ArrayBase<S, D>
     where A: Clone + $trt<B, Output=A>,
-          S: DataMut<Elem=A>,
+          S: DataOwned<Elem=A> + DataMut,
           D: Dimension,
           B: Clone + Scalar,
 {


### PR DESCRIPTION

Please see the Arithmetic Operations overview in the `ArrayBase` docs
for an easy to read overview.

Fixes #83