### PR TITLE
split_at for Array

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -935,8 +935,7 @@ impl<'a, A, D> ArrayView<'a, A, D>
         let left_ptr = self.ptr;
         let right_ptr = if index == self.shape()[axis] {
             self.ptr
-        }
-        else {
+        } else {
             let mut indices = self.dim.clone();
             for (ax, ind) in indices.slice_mut().iter_mut().enumerate() {
                 if ax != axis {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,8 @@ pub use dimension::{
     RemoveAxis,
 };
 
+use dimension::stride_offset;
+
 pub use dimension::NdIndex;
 pub use indexes::Indexes;
 pub use shape_error::ShapeError;
@@ -936,17 +938,7 @@ impl<'a, A, D> ArrayView<'a, A, D>
         let right_ptr = if index == self.shape()[axis] {
             self.ptr
         } else {
-            let mut indices = self.dim.clone();
-            for (ax, ind) in indices.slice_mut().iter_mut().enumerate() {
-                if ax != axis {
-                    *ind = 0;
-                }
-                else {
-                    *ind = index;
-                }
-            }
-            let offset = self.dim.stride_offset_checked(&self.strides,
-                                                        &indices).unwrap();
+            let offset = stride_offset(index, self.strides.slice()[axis]);
             unsafe {
                 self.ptr.offset(offset)
             }
@@ -1076,17 +1068,7 @@ impl<'a, A, D> ArrayViewMut<'a, A, D>
             self.ptr
         }
         else {
-            let mut indices = self.dim.clone();
-            for (ax, ind) in indices.slice_mut().iter_mut().enumerate() {
-                if ax != axis {
-                    *ind = 0;
-                }
-                else {
-                    *ind = index;
-                }
-            }
-            let offset = self.dim.stride_offset_checked(&self.strides,
-                                                        &indices).unwrap();
+            let offset = stride_offset(index, self.strides.slice()[axis]);
             unsafe {
                 self.ptr.offset(offset)
             }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -661,10 +661,26 @@ fn deny_wraparound_reshape() {
 
 #[test]
 fn split_at() {
-    let a = arr2(&[[1., 2.], [3., 4.]]);
+    let mut a = arr2(&[[1., 2.], [3., 4.]]);
 
-    let (c0, c1) = a.axis_split_at(1, 1);
+    {
+        let (c0, c1) = a.view().axis_split_at(1, 1);
 
-    assert_eq!(c0, arr2(&[[1.], [3.]]));
-    assert_eq!(c1, arr2(&[[2.], [4.]]));
+        assert_eq!(c0, arr2(&[[1.], [3.]]));
+        assert_eq!(c1, arr2(&[[2.], [4.]]));
+    }
+
+    {
+        let (mut r0, mut r1) = a.view_mut().axis_split_at(0, 1);
+        r0[[0, 1]] = 5.;
+        r1[[0, 0]] = 8.;
+    }
+    assert_eq!(a, arr2(&[[1., 5.], [8., 4.]]));
+
+
+    let b = RcArray::linspace(0., 59., 60).reshape((3, 4, 5));
+
+    let (left, right) = b.view().axis_split_at(2, 2);
+    assert_eq!(left.shape(), [3, 4, 2]);
+    assert_eq!(right.shape(), [3, 4, 3]);
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -7,7 +7,7 @@ extern crate ndarray;
 use ndarray::{RcArray, S, Si,
     OwnedArray,
 };
-use ndarray::{arr0, arr1, arr2,
+use ndarray::{arr0, arr1, arr2, arr3,
     aview0,
     aview1,
     aview2,
@@ -683,4 +683,25 @@ fn split_at() {
     let (left, right) = b.view().axis_split_at(2, 2);
     assert_eq!(left.shape(), [3, 4, 2]);
     assert_eq!(right.shape(), [3, 4, 3]);
+    assert_eq!(left, arr3(&[[[0., 1.], [5., 6.], [10., 11.], [15., 16.]],
+                            [[20., 21.], [25., 26.], [30., 31.], [35., 36.]],
+                            [[40., 41.], [45., 46.], [50., 51.], [55., 56.]]]));
+
+    // we allow for an empty right view when index == dim[axis]
+    let (_, right) = b.view().axis_split_at(1, 4);
+    assert_eq!(right.shape(), [3, 0, 5]);
+}
+
+#[test]
+#[should_panic]
+fn deny_split_at_axis_out_of_bounds() {
+    let a = arr2(&[[1., 2.], [3., 4.]]);
+    a.view().axis_split_at(2, 0);
+}
+
+#[test]
+#[should_panic]
+fn deny_split_at_index_out_of_bounds() {
+    let a = arr2(&[[1., 2.], [3., 4.]]);
+    a.view().axis_split_at(1, 3);
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -658,3 +658,13 @@ fn deny_wraparound_reshape() {
     let five = OwnedArray::<f32, _>::zeros(5);
     let _five_large = five.into_shape((3, 7, 29, 36760123, 823996703)).unwrap();
 }
+
+#[test]
+fn split_at() {
+    let a = arr2(&[[1., 2.], [3., 4.]]);
+
+    let (c0, c1) = a.axis_split_at(1, 1);
+
+    assert_eq!(c0, arr2(&[[1.], [3.]]));
+    assert_eq!(c1, arr2(&[[2.], [4.]]));
+}


### PR DESCRIPTION
This PR introduces a `split_at`like family of functions for arrays. This is currently work in progress.

Status:
- [x] `axis_split_at`
- [x] `axis_split_at_mut`
- [x] tests