### PR TITLE
Not going to be merged: Statically checked axis numbers

### DIFF
--- a/examples/axis.rs
+++ b/examples/axis.rs
@@ -2,22 +2,15 @@ extern crate ndarray;
 
 use ndarray::{
     OwnedArray,
-    Ax,
-    Ax0, Ax1, Ax2,
-    AxisForDimension,
-    Ix,
+    Axis,
+    Axis0, Axis1, Axis2,
 };
-use ndarray::{Ax as Axis, Ax0 as Axis0, Ax1 as Axis1};
 
 fn main() {
     let mut a = OwnedArray::<f32, _>::linspace(0., 24., 25).into_shape((5, 5)).unwrap();
-    let x: AxisForDimension<(Ix, Ix)> = Ax(2).into();
-    let x: AxisForDimension<(Ix, Ix)> = Ax0.into();
-    let x: AxisForDimension<(Ix, Ix)> = Ax1.into();
-    //let x: AxisForDimension<(Ix, Ix)> = Ax2.into();
-    println!("{:?}", x);
     println!("{:?}", a.subview(Axis0, 0));
     println!("{:?}", a.subview(Axis0, 1));
     println!("{:?}", a.subview(Axis1, 1));
+    //println!("{:?}", a.subview(Axis2, 1));
     println!("{:?}", a.subview(Axis(0), 1));
 }

--- a/examples/axis.rs
+++ b/examples/axis.rs
@@ -1,0 +1,23 @@
+extern crate ndarray;
+
+use ndarray::{
+    OwnedArray,
+    Ax,
+    Ax0, Ax1, Ax2,
+    AxisForDimension,
+    Ix,
+};
+use ndarray::{Ax as Axis, Ax0 as Axis0, Ax1 as Axis1};
+
+fn main() {
+    let mut a = OwnedArray::<f32, _>::linspace(0., 24., 25).into_shape((5, 5)).unwrap();
+    let x: AxisForDimension<(Ix, Ix)> = Ax(2).into();
+    let x: AxisForDimension<(Ix, Ix)> = Ax0.into();
+    let x: AxisForDimension<(Ix, Ix)> = Ax1.into();
+    //let x: AxisForDimension<(Ix, Ix)> = Ax2.into();
+    println!("{:?}", x);
+    println!("{:?}", a.subview(Axis0, 0));
+    println!("{:?}", a.subview(Axis0, 1));
+    println!("{:?}", a.subview(Axis1, 1));
+    println!("{:?}", a.subview(Axis(0), 1));
+}

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -141,6 +141,7 @@ pub unsafe trait Dimension : Clone + Eq {
     /// The easiest way to create a `&SliceArg` is using the macro
     /// [`s![]`](macro.s!.html).
     type SliceArg: ?Sized + AsRef<[Si]>;
+    type AxisArg: Copy + Axis;
     #[doc(hidden)]
     fn ndim(&self) -> usize;
     #[doc(hidden)]
@@ -355,6 +356,7 @@ pub fn do_sub<A, D: Dimension>(dims: &mut D, ptr: &mut *mut A, strides: &D,
 
 unsafe impl Dimension for () {
     type SliceArg = [Si; 0];
+    type AxisArg = VoidAxis;
     // empty product is 1 -> size is 1
     #[inline]
     fn ndim(&self) -> usize { 0 }
@@ -364,6 +366,7 @@ unsafe impl Dimension for () {
 
 unsafe impl Dimension for Ix {
     type SliceArg = [Si; 1];
+    type AxisArg = Axes0;
     #[inline]
     fn ndim(&self) -> usize { 1 }
     #[inline]
@@ -411,6 +414,7 @@ unsafe impl Dimension for Ix {
 
 unsafe impl Dimension for (Ix, Ix) {
     type SliceArg = [Si; 2];
+    type AxisArg = Axes1;
     #[inline]
     fn ndim(&self) -> usize { 2 }
 
@@ -479,6 +483,7 @@ unsafe impl Dimension for (Ix, Ix) {
 
 unsafe impl Dimension for (Ix, Ix, Ix) {
     type SliceArg = [Si; 3];
+    type AxisArg = Axes2;
     #[inline]
     fn ndim(&self) -> usize { 3 }
     #[inline]
@@ -515,6 +520,7 @@ macro_rules! large_dim {
     ($n:expr, $($ix:ident),+) => (
         unsafe impl Dimension for ($($ix),+) {
             type SliceArg = [Si; $n];
+            type AxisArg = usize;
             #[inline]
             fn ndim(&self) -> usize { $n }
         }
@@ -536,6 +542,7 @@ large_dim!(12, Ix, Ix, Ix, Ix, Ix, Ix, Ix, Ix, Ix, Ix, Ix, Ix);
 unsafe impl Dimension for Vec<Ix>
 {
     type SliceArg = [Si];
+    type AxisArg = usize;
     fn ndim(&self) -> usize { self.len() }
     fn slice(&self) -> &[Ix] { self }
     fn slice_mut(&mut self) -> &mut [Ix] { self }
@@ -713,5 +720,97 @@ mod test {
         assert!(!super::dim_stride_overlap(&dim, &strides));
         let strides = (6, 0, 1);
         assert!(super::dim_stride_overlap(&dim, &strides));
+    }
+}
+
+pub trait Axis {
+    fn axis(&self) -> usize;
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum VoidAxis { }
+#[derive(Copy, Clone, Debug)]
+pub struct Axes0(usize);
+#[derive(Copy, Clone, Debug)]
+pub struct Axes1(usize);
+#[derive(Copy, Clone, Debug)]
+pub struct Axes2(usize);
+#[derive(Copy, Clone, Debug)]
+pub struct Axes3(usize);
+
+impl Axis for VoidAxis { fn axis(&self) -> usize { match *self { } } }
+impl Axis for Axes0 { fn axis(&self) -> usize { self.0 } }
+impl Axis for Axes1 { fn axis(&self) -> usize { self.0 } }
+impl Axis for Axes2 { fn axis(&self) -> usize { self.0 } }
+impl Axis for Axes3 { fn axis(&self) -> usize { self.0 } }
+
+#[derive(Copy, Clone, Debug)]
+pub struct Ax0;
+#[derive(Copy, Clone, Debug)]
+pub struct Ax1;
+#[derive(Copy, Clone, Debug)]
+pub struct Ax2;
+#[derive(Copy, Clone, Debug)]
+pub struct Ax3;
+
+impl Axis for Ax0 { fn axis(&self) -> usize { 0 } }
+impl Axis for Ax1 { fn axis(&self) -> usize { 1 } }
+impl Axis for Ax2 { fn axis(&self) -> usize { 2 } }
+impl Axis for Ax3 { fn axis(&self) -> usize { 3 } }
+impl Axis for usize { fn axis(&self) -> usize { *self } }
+
+impl Into<VoidAxis> for usize {
+    fn into(self) -> VoidAxis {
+        panic!("VoidAxis: zero-dimensional arrays have no axes")
+    }
+}
+
+impl Into<usize> for Ax0 { fn into(self) -> usize { 0 } }
+impl Into<usize> for Ax1 { fn into(self) -> usize { 1 } }
+impl Into<usize> for Ax2 { fn into(self) -> usize { 2 } }
+impl Into<usize> for Ax3 { fn into(self) -> usize { 3 } }
+
+impl Into<Axes0> for Ax0 {
+    fn into(self) -> Axes0 { Axes0(0) }
+}
+
+impl Into<Axes0> for usize {
+    fn into(self) -> Axes0 {
+        assert!(self == 0);
+        Axes0(self)
+    }
+}
+
+impl Into<Axes1> for Ax0 {
+    fn into(self) -> Axes1 { Axes1(self.axis()) }
+}
+
+impl Into<Axes1> for Ax1 {
+    fn into(self) -> Axes1 { Axes1(self.axis()) }
+}
+
+impl Into<Axes1> for usize {
+    fn into(self) -> Axes1 {
+        assert!(self <= 1);
+        Axes1(self)
+    }
+}
+
+impl Into<Axes2> for Ax0 {
+    fn into(self) -> Axes2 { Axes2(self.axis()) }
+}
+
+impl Into<Axes2> for Ax1 {
+    fn into(self) -> Axes2 { Axes2(self.axis()) }
+}
+
+impl Into<Axes2> for Ax2 {
+    fn into(self) -> Axes2 { Axes2(self.axis()) }
+}
+
+impl Into<Axes2> for usize {
+    fn into(self) -> Axes2 {
+        assert!(self <= 2);
+        Axes2(self)
     }
 }

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -747,6 +747,16 @@ impl<D> From<Axis> for AxisForDimension<D> {
     }
 }
 
+#[cfg_attr(has_deprecated, deprecated(note="Usize arguments for `axis` are deprecated. Use `Axis` instead."))]
+impl<D> From<usize> for AxisForDimension<D> {
+    fn from(x: usize) -> Self {
+        AxisForDimension {
+            axis: x,
+            dim: PhantomData,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub struct Axis0;
 #[derive(Copy, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1431,10 +1431,11 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// See [*Subviews*](#subviews) for full documentation.
     ///
     /// **Panics** if `axis` is out of bounds.
-    pub fn axis_iter(&self, axis: usize) -> OuterIter<A, D::Smaller>
-        where D: RemoveAxis
+    pub fn axis_iter<Ax>(&self, axis: Ax) -> OuterIter<A, D::Smaller>
+        where D: RemoveAxis,
+              Ax: Into<AxisForDimension<D>>,
     {
-        iterators::new_axis_iter(self.view(), axis)
+        iterators::new_axis_iter(self.view(), axis.into().axis())
     }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ use itertools::free::enumerate;
 pub use dimension::{
     Dimension,
     RemoveAxis,
-    Ax0, Ax1, Ax2, Ax3, Ax,
+    Axis0, Axis1, Axis2, Axis3, Axis,
 };
 
 pub use dimension::NdIndex;
@@ -115,7 +115,6 @@ pub use linalg::LinalgScalar;
 
 pub use dimension::{
     AxisForDimension,
-    Axis,
 };
 
 mod arraytraits;
@@ -2431,7 +2430,7 @@ impl<A, S> ArrayBase<S, (Ix, Ix)>
     /// **Panics** if `index` is out of bounds.
     pub fn row(&self, index: Ix) -> ArrayView<A, Ix>
     {
-        self.subview(Ax0, index)
+        self.subview(Axis0, index)
     }
 
     /// Return a mutable array view of row `index`.
@@ -2440,7 +2439,7 @@ impl<A, S> ArrayBase<S, (Ix, Ix)>
     pub fn row_mut(&mut self, index: Ix) -> ArrayViewMut<A, Ix>
         where S: DataMut
     {
-        self.subview_mut(Ax0, index)
+        self.subview_mut(Axis0, index)
     }
 
     /// Return an array view of column `index`.
@@ -2448,7 +2447,7 @@ impl<A, S> ArrayBase<S, (Ix, Ix)>
     /// **Panics** if `index` is out of bounds.
     pub fn column(&self, index: Ix) -> ArrayView<A, Ix>
     {
-        self.subview(Ax1, index)
+        self.subview(Axis1, index)
     }
 
     /// Return a mutable array view of column `index`.
@@ -2457,7 +2456,7 @@ impl<A, S> ArrayBase<S, (Ix, Ix)>
     pub fn column_mut(&mut self, index: Ix) -> ArrayViewMut<A, Ix>
         where S: DataMut
     {
-        self.subview_mut(Ax1, index)
+        self.subview_mut(Axis1, index)
     }
 
     /// Perform matrix multiplication of rectangular arrays `self` and `rhs`.

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -14,6 +14,7 @@ use ndarray::{arr0, arr1, arr2,
     aview_mut1,
 };
 use ndarray::Indexes;
+use ndarray::{Axis, Axis0, Axis1, Axis2};
 
 #[test]
 fn test_matmul_rcarray()
@@ -284,12 +285,12 @@ fn assign()
 fn sum_mean()
 {
     let a = arr2(&[[1., 2.], [3., 4.]]);
-    assert_eq!(a.sum(0), arr1(&[4., 6.]));
-    assert_eq!(a.sum(1), arr1(&[3., 7.]));
-    assert_eq!(a.mean(0), arr1(&[2., 3.]));
-    assert_eq!(a.mean(1), arr1(&[1.5, 3.5]));
-    assert_eq!(a.sum(1).sum(0), arr0(10.));
-    assert_eq!(a.view().mean(1), aview1(&[1.5, 3.5]));
+    assert_eq!(a.sum(Axis0), arr1(&[4., 6.]));
+    assert_eq!(a.sum(Axis1), arr1(&[3., 7.]));
+    assert_eq!(a.mean(Axis0), arr1(&[2., 3.]));
+    assert_eq!(a.mean(Axis1), arr1(&[1.5, 3.5]));
+    assert_eq!(a.sum(Axis1).sum(Axis0), arr0(10.));
+    assert_eq!(a.view().mean(Axis1), aview1(&[1.5, 3.5]));
     assert_eq!(a.scalar_sum(), 10.);
 }
 

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -5,7 +5,7 @@ use ndarray::{
     OwnedArray,
     RemoveAxis,
     arr2,
-    Ax0, Ax1, Ax2,
+    Axis0, Axis1, Axis2,
 };
 
 #[test]
@@ -19,10 +19,10 @@ fn remove_axis()
     assert_eq!(vec![4, 5, 6].remove_axis(1), vec![4, 6]);
 
     let a = RcArray::<f32, _>::zeros((4,5));
-    a.subview(Ax1, 0);
+    a.subview(Axis1, 0);
 
     let a = RcArray::<f32, _>::zeros(vec![4,5,6]);
-    let _b = a.subview(Ax1, 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
+    let _b = a.subview(Axis1, 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
     
 }
 

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -5,6 +5,7 @@ use ndarray::{
     OwnedArray,
     RemoveAxis,
     arr2,
+    Axis,
     Axis0, Axis1, Axis2,
 };
 
@@ -22,7 +23,7 @@ fn remove_axis()
     a.subview(Axis1, 0);
 
     let a = RcArray::<f32, _>::zeros(vec![4,5,6]);
-    let _b = a.subview(Axis1, 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
+    let _b = a.into_subview(Axis(1), 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
     
 }
 

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -5,6 +5,7 @@ use ndarray::{
     OwnedArray,
     RemoveAxis,
     arr2,
+    Ax0, Ax1, Ax2,
 };
 
 #[test]
@@ -17,8 +18,11 @@ fn remove_axis()
     assert_eq!(vec![1,2].remove_axis(0), vec![2]);
     assert_eq!(vec![4, 5, 6].remove_axis(1), vec![4, 6]);
 
+    let a = RcArray::<f32, _>::zeros((4,5));
+    a.subview(Ax1, 0);
+
     let a = RcArray::<f32, _>::zeros(vec![4,5,6]);
-    let _b = a.into_subview(1, 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
+    let _b = a.subview(Ax1, 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
     
 }
 


### PR DESCRIPTION
This approach is posted here to show it, but this will not be merged.

It uses `Axis(usize)` for dynamic axis indexing, and statically checked `Axis0, Axis1` etc that can be checked against the array dimension using the type system.

This allows some degree of static checking. However, I think this system does not carry its own costs -- it introduces more generics for very little benefit. Instead I will post a simpler non generic approach.