### PR TITLE
Strongly typed Axis argument (newtype called Axis)

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -12,6 +12,7 @@ use rblas::matrix::Matrix;
 
 use ndarray::{
     OwnedArray,
+    Axis,
 };
 use ndarray::{arr0, arr1, arr2};
 
@@ -562,5 +563,5 @@ fn dot_f32_1024(bench: &mut test::Bencher)
 fn means(bench: &mut test::Bencher) {
     let a = OwnedArray::from_iter(0..100_000i64);
     let a = a.into_shape((100, 1000)).unwrap();
-    bench.iter(|| a.mean(0));
+    bench.iter(|| a.mean(Axis(0)));
 }

--- a/examples/axis.rs
+++ b/examples/axis.rs
@@ -1,0 +1,15 @@
+extern crate ndarray;
+
+use ndarray::{
+    OwnedArray,
+    Axis,
+};
+
+fn main() {
+    let a = OwnedArray::<f32, _>::linspace(0., 24., 25).into_shape((5, 5)).unwrap();
+    println!("{:?}", a.subview(Axis(0), 0));
+    println!("{:?}", a.subview(Axis(0), 1));
+    println!("{:?}", a.subview(Axis(1), 1));
+    println!("{:?}", a.subview(Axis(0), 1));
+    println!("{:?}", a.subview(Axis(2), 1)); // PANIC
+}

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -715,3 +715,13 @@ mod test {
         assert!(super::dim_stride_overlap(&dim, &strides));
     }
 }
+
+/// An axis index.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Axis(pub usize);
+
+impl Axis {
+    #[inline(always)]
+    pub fn axis(&self) -> usize { self.0 }
+}
+

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -14,6 +14,7 @@ use ndarray::{arr0, arr1, arr2,
     aview_mut1,
 };
 use ndarray::Indexes;
+use ndarray::Axis;
 
 #[test]
 fn test_matmul_rcarray()
@@ -201,14 +202,14 @@ fn test_cow()
 fn test_sub()
 {
     let mat = RcArray::linspace(0., 15., 16).reshape((2, 4, 2));
-    let s1 = mat.subview(0,0);
-    let s2 = mat.subview(0,1);
+    let s1 = mat.subview(Axis(0),0);
+    let s2 = mat.subview(Axis(0),1);
     assert_eq!(s1.dim(), (4, 2));
     assert_eq!(s2.dim(), (4, 2));
     let n = RcArray::linspace(8., 15., 8).reshape((4,2));
     assert_eq!(n, s2);
     let m = RcArray::from_vec(vec![2., 3., 10., 11.]).reshape((2, 2));
-    assert_eq!(m, mat.subview(1, 1));
+    assert_eq!(m, mat.subview(Axis(1), 1));
 }
 
 #[test]
@@ -248,9 +249,9 @@ fn standard_layout()
     assert!(!a.is_standard_layout());
     a.swap_axes(0, 1);
     assert!(a.is_standard_layout());
-    let x1 = a.subview(0, 0);
+    let x1 = a.subview(Axis(0), 0);
     assert!(x1.is_standard_layout());
-    let x2 = a.subview(1, 0);
+    let x2 = a.subview(Axis(1), 0);
     assert!(!x2.is_standard_layout());
 }
 
@@ -284,12 +285,12 @@ fn assign()
 fn sum_mean()
 {
     let a = arr2(&[[1., 2.], [3., 4.]]);
-    assert_eq!(a.sum(0), arr1(&[4., 6.]));
-    assert_eq!(a.sum(1), arr1(&[3., 7.]));
-    assert_eq!(a.mean(0), arr1(&[2., 3.]));
-    assert_eq!(a.mean(1), arr1(&[1.5, 3.5]));
-    assert_eq!(a.sum(1).sum(0), arr0(10.));
-    assert_eq!(a.view().mean(1), aview1(&[1.5, 3.5]));
+    assert_eq!(a.sum(Axis(0)), arr1(&[4., 6.]));
+    assert_eq!(a.sum(Axis(1)), arr1(&[3., 7.]));
+    assert_eq!(a.mean(Axis(0)), arr1(&[2., 3.]));
+    assert_eq!(a.mean(Axis(1)), arr1(&[1.5, 3.5]));
+    assert_eq!(a.sum(Axis(1)).sum(Axis(0)), arr0(10.));
+    assert_eq!(a.view().mean(Axis(1)), aview1(&[1.5, 3.5]));
     assert_eq!(a.scalar_sum(), 10.);
 }
 
@@ -341,7 +342,7 @@ fn zero_axes()
     println!("{:?}\n{:?}", b.shape(), b);
 
     // we can even get a subarray of b
-    let bsub = b.subview(0, 2);
+    let bsub = b.subview(Axis(0), 2);
     assert_eq!(bsub.dim(), 0);
 }
 
@@ -595,7 +596,7 @@ fn char_array()
 {
     // test compilation & basics of non-numerical array
     let cc = RcArray::from_iter("alphabet".chars()).reshape((4, 2));
-    assert!(cc.subview(1, 0) == RcArray::from_iter("apae".chars()));
+    assert!(cc.subview(Axis(1), 0) == RcArray::from_iter("apae".chars()));
 }
 
 #[test]

--- a/tests/complex.rs
+++ b/tests/complex.rs
@@ -2,7 +2,7 @@
 extern crate num;
 extern crate ndarray;
 
-use ndarray::{arr1, arr2};
+use ndarray::{arr1, arr2, Axis};
 use ndarray::OwnedArray;
 use num::{Num, Complex};
 
@@ -20,5 +20,5 @@ fn complex_mat_mul()
     let r = a.mat_mul(&e);
     println!("{}", a);
     assert_eq!(r, a);
-    assert_eq!(a.mean(0), arr1(&[c(1.5, 1.), c(2.5, 0.)]));
+    assert_eq!(a.mean(Axis(0)), arr1(&[c(1.5, 1.), c(2.5, 0.)]));
 }

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -5,6 +5,7 @@ use ndarray::{
     OwnedArray,
     RemoveAxis,
     arr2,
+    Axis,
 };
 
 #[test]
@@ -17,8 +18,11 @@ fn remove_axis()
     assert_eq!(vec![1,2].remove_axis(0), vec![2]);
     assert_eq!(vec![4, 5, 6].remove_axis(1), vec![4, 6]);
 
+    let a = RcArray::<f32, _>::zeros((4,5));
+    a.subview(Axis(1), 0);
+
     let a = RcArray::<f32, _>::zeros(vec![4,5,6]);
-    let _b = a.into_subview(1, 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
+    let _b = a.into_subview(Axis(1), 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
     
 }
 

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -11,6 +11,7 @@ use ndarray::{
     aview1,
     arr2,
     arr3,
+    Axis,
 };
 
 use itertools::assert_equal;
@@ -89,12 +90,12 @@ fn as_slice() {
     let a = a.reshape((2, 4));
     assert_slice_correct(&a);
 
-    assert!(a.view().subview(1, 0).as_slice().is_none());
+    assert!(a.view().subview(Axis(1), 0).as_slice().is_none());
 
     let v = a.view();
     assert_slice_correct(&v);
-    assert_slice_correct(&v.subview(0, 0));
-    assert_slice_correct(&v.subview(0, 1));
+    assert_slice_correct(&v.subview(Axis(0), 0));
+    assert_slice_correct(&v.subview(Axis(0), 1));
 
     assert!(v.slice(&[S, Si(0, Some(1), 1)]).as_slice().is_none());
     println!("{:?}", v.slice(&[Si(0, Some(1), 2), S]));
@@ -176,12 +177,12 @@ fn outer_iter() {
     //   [8, 9],
     //    ...
     assert_equal(a.outer_iter(),
-                 vec![a.subview(0, 0), a.subview(0, 1)]);
+                 vec![a.subview(Axis(0), 0), a.subview(Axis(0), 1)]);
     let mut b = RcArray::zeros((2, 3, 2));
     b.swap_axes(0, 2);
     b.assign(&a);
     assert_equal(b.outer_iter(),
-                 vec![a.subview(0, 0), a.subview(0, 1)]);
+                 vec![a.subview(Axis(0), 0), a.subview(Axis(0), 1)]);
 
     let mut found_rows = Vec::new();
     for sub in b.outer_iter() {
@@ -206,7 +207,7 @@ fn outer_iter() {
     cv.assign(&a);
     assert_eq!(&a, &cv);
     assert_equal(cv.outer_iter(),
-                 vec![a.subview(0, 0), a.subview(0, 1)]);
+                 vec![a.subview(Axis(0), 0), a.subview(Axis(0), 1)]);
 
     let mut found_rows = Vec::new();
     for sub in cv.outer_iter() {
@@ -228,10 +229,10 @@ fn axis_iter() {
     //  [[6, 7],
     //   [8, 9],
     //    ...
-    assert_equal(a.axis_iter(1),
-                 vec![a.subview(1, 0),
-                      a.subview(1, 1),
-                      a.subview(1, 2)]);
+    assert_equal(a.axis_iter(Axis(1)),
+                 vec![a.subview(Axis(1), 0),
+                      a.subview(Axis(1), 1),
+                      a.subview(Axis(1), 2)]);
 }
 
 #[test]
@@ -259,7 +260,7 @@ fn outer_iter_mut() {
     b.swap_axes(0, 2);
     b.assign(&a);
     assert_equal(b.outer_iter_mut(),
-                 vec![a.subview(0, 0), a.subview(0, 1)]);
+                 vec![a.subview(Axis(0), 0), a.subview(Axis(0), 1)]);
 
     let mut found_rows = Vec::new();
     for sub in b.outer_iter_mut() {
@@ -282,7 +283,7 @@ fn axis_iter_mut() {
     //    ...
     let mut a = a.to_owned();
 
-    for mut subview in a.axis_iter_mut(1) {
+    for mut subview in a.axis_iter_mut(Axis(1)) {
         subview[[0, 0]] = 42;
     }
 
@@ -300,7 +301,7 @@ fn axis_chunks_iter() {
     let a = RcArray::from_iter(0..24);
     let a = a.reshape((2, 6, 2));
 
-    let it = a.axis_chunks_iter(1, 2);
+    let it = a.axis_chunks_iter(Axis(1), 2);
     assert_equal(it,
                  vec![arr3(&[[[0, 1], [2, 3]], [[12, 13], [14, 15]]]),
                       arr3(&[[[4, 5], [6, 7]], [[16, 17], [18, 19]]]),
@@ -309,24 +310,24 @@ fn axis_chunks_iter() {
     let a = RcArray::from_iter(0..28);
     let a = a.reshape((2, 7, 2));
 
-    let it = a.axis_chunks_iter(1, 2);
+    let it = a.axis_chunks_iter(Axis(1), 2);
     assert_equal(it,
                  vec![arr3(&[[[0, 1], [2, 3]], [[14, 15], [16, 17]]]),
                       arr3(&[[[4, 5], [6, 7]], [[18, 19], [20, 21]]]),
                       arr3(&[[[8, 9], [10, 11]], [[22, 23], [24, 25]]]),
                       arr3(&[[[12, 13]], [[26, 27]]])]);
 
-    let it = a.axis_chunks_iter(1, 2).rev();
+    let it = a.axis_chunks_iter(Axis(1), 2).rev();
     assert_equal(it,
                  vec![arr3(&[[[12, 13]], [[26, 27]]]),
                       arr3(&[[[8, 9], [10, 11]], [[22, 23], [24, 25]]]),
                       arr3(&[[[4, 5], [6, 7]], [[18, 19], [20, 21]]]),
                       arr3(&[[[0, 1], [2, 3]], [[14, 15], [16, 17]]])]);
 
-    let it = a.axis_chunks_iter(1, 7);
+    let it = a.axis_chunks_iter(Axis(1), 7);
     assert_equal(it, vec![a.view()]);
 
-    let it = a.axis_chunks_iter(1, 9);
+    let it = a.axis_chunks_iter(Axis(1), 9);
     assert_equal(it, vec![a.view()]);
 }
 
@@ -338,12 +339,12 @@ fn axis_chunks_iter_corner_cases() {
     // checking the absence of of out of bounds offseting cannot (?) be
     // done automatically, so one has to launch this test in a debugger.
     let a = RcArray::<f32, _>::linspace(0., 7., 8).reshape((8, 1));
-    let it = a.axis_chunks_iter(0, 4);
+    let it = a.axis_chunks_iter(Axis(0), 4);
     assert_equal(it, vec![a.slice(s![..4, ..]), a.slice(s![4.., ..])]);
     let a = a.slice(s![..;-1,..]);
-    let it = a.axis_chunks_iter(0, 8);
+    let it = a.axis_chunks_iter(Axis(0), 8);
     assert_equal(it, vec![a.view()]);
-    let it = a.axis_chunks_iter(0, 3);
+    let it = a.axis_chunks_iter(Axis(0), 3);
     assert_equal(it,
                  vec![arr2(&[[7.], [6.], [5.]]),
                       arr2(&[[4.], [3.], [2.]]),
@@ -351,10 +352,10 @@ fn axis_chunks_iter_corner_cases() {
 
     let b = RcArray::<f32, _>::zeros((8, 2));
     let a = b.slice(s![1..;2,..]);
-    let it = a.axis_chunks_iter(0, 8);
+    let it = a.axis_chunks_iter(Axis(0), 8);
     assert_equal(it, vec![a.view()]);
 
-    let it = a.axis_chunks_iter(0, 1);
+    let it = a.axis_chunks_iter(Axis(0), 1);
     assert_equal(it, vec![RcArray::zeros((1, 2)); 4]);
 }
 
@@ -363,7 +364,7 @@ fn axis_chunks_iter_mut() {
     let a = RcArray::from_iter(0..24);
     let mut a = a.reshape((2, 6, 2));
 
-    let mut it = a.axis_chunks_iter_mut(1, 2);
+    let mut it = a.axis_chunks_iter_mut(Axis(1), 2);
     let mut col0 = it.next().unwrap();
     col0[[0, 0, 0]] = 42;
     assert_eq!(col0, arr3(&[[[42, 1], [2, 3]], [[12, 13], [14, 15]]]));


### PR DESCRIPTION
Use a newtype `Axis(usize)` for all method arguments that need an axis.