### PR TITLE
Add a trait `NdFloat`

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 #![allow(unused_imports)]
-#![cfg_attr(feature = "assign_ops", feature(augmented_assignments))]
 
 extern crate test;
 #[macro_use(s)]
@@ -246,7 +245,6 @@ fn add_2d_regular(bench: &mut test::Bencher)
     });
 }
 
-#[cfg(feature = "assign_ops")]
 #[bench]
 fn add_2d_assign_ops(bench: &mut test::Bencher)
 {

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -41,12 +41,12 @@ macro_rules! debug_bounds_check {
 }
 
 #[inline(always)]
-pub fn debug_bounds_check<S, D, I>(a: &ArrayBase<S, D>, index: &I)
+pub fn debug_bounds_check<S, D, I>(_a: &ArrayBase<S, D>, _index: &I)
     where D: Dimension,
           I: NdIndex<Dim=D>,
           S: Data,
 {
-    debug_bounds_check!(a, *index);
+    debug_bounds_check!(_a, *_index);
 }
 
 /// Access the element at **index**.

--- a/src/impl_numeric.rs
+++ b/src/impl_numeric.rs
@@ -7,6 +7,7 @@ use numeric_util;
 
 use {
     LinalgScalar,
+    aview0,
 };
 
 impl<A, S, D> ArrayBase<S, D>
@@ -87,14 +88,12 @@ impl<A, S, D> ArrayBase<S, D>
               D: RemoveAxis,
     {
         let n = self.shape()[axis.axis()];
-        let mut sum = self.sum(axis);
-        let one = libnum::one::<A>();
-        let mut cnt = one;
+        let sum = self.sum(axis);
+        let mut cnt = A::one();
         for _ in 1..n {
-            cnt = cnt + one;
+            cnt = cnt + A::one();
         }
-        sum.idiv_scalar(&cnt);
-        sum
+        sum / &aview0(&cnt)
     }
 
     /// Return `true` if the arrays' elementwise differences are all within

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -12,11 +12,11 @@ use libnum::Complex;
 /// and let `C` be an array with mutable data.
 ///
 /// `ScalarOperand` determines for which scalars `K` operations `&A @ K`, and `B @ K`,
-/// and `C @= K` are defined, as **right hand side** operands, for applicable
+/// and `C @= K` are defined, as ***right hand side operands***, for applicable
 /// arithmetic operators (denoted `@`).
 ///
-/// **Left hand side** scalar operands are implemented differently
-/// (one `impl` per concrete scalar type); they are
+/// ***Left hand side*** scalar operands are not related to this trait.
+/// (They need one `impl` per concrete scalar type); they are
 /// implemented for the default `ScalarOperand` types, allowing
 /// operations `K @ &A`, and `K @ B`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,6 @@ pub use iterators::{
 };
 
 pub use arraytraits::AsArray;
-pub use linalg::LinalgScalar;
 pub use linalg::{LinalgScalar, NdFloat};
 
 mod arraytraits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub use iterators::{
 
 pub use arraytraits::AsArray;
 pub use linalg::LinalgScalar;
+pub use linalg::{LinalgScalar, NdFloat};
 
 mod arraytraits;
 #[cfg(feature = "serde")]

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -54,10 +54,10 @@ impl<T> LinalgScalar for T
 
 /// Floating-point element types `f32` and `f64`.
 ///
-/// Trait `NdFloat` is only implemented for `f32` and `f64` but
-/// encompasses all float-relevant ndarray functionality,
-/// including the traits needed for linear algebra (`Any`) and
-/// for scalar operations (`ScalarOperand`).
+/// Trait `NdFloat` is only implemented for `f32` and `f64` but encompasses as
+/// much float-relevant ndarray functionality as possible, including the traits
+/// needed for linear algebra (`Any`) and for *right hand side* scalar
+/// operations (`ScalarOperand`).
 #[cfg(not(feature="assign_ops"))]
 pub trait NdFloat :
     Float +
@@ -67,10 +67,10 @@ pub trait NdFloat :
 
 /// Floating-point element types `f32` and `f64`.
 ///
-/// Trait `NdFloat` is only implemented for `f32` and `f64` but
-/// encompasses all float-relevant ndarray functionality,
-/// including the traits needed for linear algebra (`Any`) and
-/// for scalar operations (`ScalarOperand`).
+/// Trait `NdFloat` is only implemented for `f32` and `f64` but encompasses as
+/// much float-relevant ndarray functionality as possible, including the traits
+/// needed for linear algebra (`Any`) and for *right hand side* scalar
+/// operations (`ScalarOperand`).
 #[cfg(feature="assign_ops")]
 pub trait NdFloat :
     Float +

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -1,6 +1,16 @@
-use libnum::{Zero, One};
-use std::ops::{Add, Sub, Mul, Div};
+use libnum::{Zero, One, Float};
 use std::any::Any;
+use std::fmt;
+use std::ops::{Add, Sub, Mul, Div};
+#[cfg(feature="assign_ops")]
+use std::ops::{
+    AddAssign,
+    SubAssign,
+    MulAssign,
+    DivAssign,
+    RemAssign,
+};
+use ScalarOperand;
 
 #[cfg(feature="rblas")]
 use std::any::TypeId;
@@ -41,6 +51,37 @@ impl<T> LinalgScalar for T
     Mul<Output=T> +
     Div<Output=T>
 { }
+
+/// Floating-point element types `f32` and `f64`.
+///
+/// Trait `NdFloat` is only implemented for `f32` and `f64` but
+/// encompasses all float-relevant ndarray functionality,
+/// including the traits needed for linear algebra (`Any`) and
+/// for scalar operations (`ScalarOperand`).
+#[cfg(not(feature="assign_ops"))]
+pub trait NdFloat :
+    Float +
+    fmt::Display + fmt::Debug + fmt::LowerExp + fmt::UpperExp +
+    ScalarOperand + LinalgScalar
+{ }
+
+/// Floating-point element types `f32` and `f64`.
+///
+/// Trait `NdFloat` is only implemented for `f32` and `f64` but
+/// encompasses all float-relevant ndarray functionality,
+/// including the traits needed for linear algebra (`Any`) and
+/// for scalar operations (`ScalarOperand`).
+#[cfg(feature="assign_ops")]
+pub trait NdFloat :
+    Float +
+    AddAssign + SubAssign + MulAssign + DivAssign + RemAssign +
+    fmt::Display + fmt::Debug + fmt::LowerExp + fmt::UpperExp +
+    ScalarOperand + LinalgScalar
+{ }
+
+impl NdFloat for f32 { }
+impl NdFloat for f64 { }
+
 
 #[cfg(feature = "rblas")]
 pub trait AsBlasAny<A, S, D> : AsBlas<A, S, D> {


### PR DESCRIPTION
The intention is to make it easy to work with f32 or f64, and have access to all ndarray operations.

However — the scalar operations on the left hand side are not cooperating with this :disappointed:

Closes #112 

### Is `NdFloat` needed?

It's not needed to use ndarray, but it makes it easier for the case where you only care about f32, f64.

### Why do we need a trait more than `num::Float`?

It would be the easiest if no new trait bounds were needed.

- `Any` is needed for type-based specialization (needed for future transparent blas support)
- `ScalarOperand` is needed as a marker trait so that arithmetic operators `Array + k` where `k` is a scalar can be implemented. I suspect this is not strictly needed, but limitations in Rust's current trait matching seem to require it.

With these two already being needed, we can take the opportunity to add-on traits that we want to have accessible in float-generic code, like the += operators and formatting traits.

### Why is `Array + scalar` included but `scalar + Array` is not?

*Left hand side* scalar operands seem entirely unreachable from generics. It's unfortunate, but not much we can do in rust as it is now. f32 + Array is implemented, it's just that we can't really capture that in `NdFloat`.