### PR TITLE
Add `From` impls and convenience trait `AsArray` that makes it easy to receive array views

### DIFF
--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -275,3 +275,38 @@ impl<A, S, D> Decodable for ArrayBase<S, D>
         })
     }
 }
+
+
+impl<'a, A, Slice: ?Sized> From<&'a Slice> for ArrayView<'a, A, Ix>
+    where Slice: AsRef<[A]>
+{
+    fn from(slice: &'a Slice) -> Self {
+        ArrayView::from_slice(slice.as_ref())
+    }
+}
+
+impl<'a, A, S, D> From<&'a ArrayBase<S, D>> for ArrayView<'a, A, D>
+    where S: Data<Elem=A>,
+          D: Dimension,
+{
+    fn from(array: &'a ArrayBase<S, D>) -> Self {
+        array.view()
+    }
+}
+
+impl<'a, A, Slice: ?Sized> From<&'a mut Slice> for ArrayViewMut<'a, A, Ix>
+    where Slice: AsMut<[A]>
+{
+    fn from(slice: &'a mut Slice) -> Self {
+        ArrayViewMut::from_slice(slice.as_mut())
+    }
+}
+
+impl<'a, A, S, D> From<&'a mut ArrayBase<S, D>> for ArrayViewMut<'a, A, D>
+    where S: DataMut<Elem=A>,
+          D: Dimension,
+{
+    fn from(array: &'a mut ArrayBase<S, D>) -> Self {
+        array.view_mut()
+    }
+}

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -9,16 +9,10 @@ use std::ops::{
     IndexMut,
 };
 
-use super::{
-    Dimension, Ix,
+use imp_prelude::*;
+use {
     Elements,
     ElementsMut,
-    ArrayBase,
-    ArrayView,
-    ArrayViewMut,
-    Data,
-    DataMut,
-    DataOwned,
     NdIndex,
 };
 
@@ -277,8 +271,11 @@ impl<A, S, D> Decodable for ArrayBase<S, D>
 }
 
 
+// use "raw" form instead of type aliases here so that they show up in docs
+/// Implementation of `ArrayView::from(&S)` where `S` is a slice or slicable.
+///
 /// Create a one-dimensional read-only array view of the data in `slice`.
-impl<'a, A, Slice: ?Sized> From<&'a Slice> for ArrayView<'a, A, Ix>
+impl<'a, A, Slice: ?Sized> From<&'a Slice> for ArrayBase<ViewRepr<&'a A>, Ix>
     where Slice: AsRef<[A]>
 {
     fn from(slice: &'a Slice) -> Self {
@@ -289,7 +286,10 @@ impl<'a, A, Slice: ?Sized> From<&'a Slice> for ArrayView<'a, A, Ix>
     }
 }
 
-impl<'a, A, S, D> From<&'a ArrayBase<S, D>> for ArrayView<'a, A, D>
+/// Implementation of `ArrayView::from(&A)` where `A` is an array.
+///
+/// Create a read-only array view of the array.
+impl<'a, A, S, D> From<&'a ArrayBase<S, D>> for ArrayBase<ViewRepr<&'a A>, D>
     where S: Data<Elem=A>,
           D: Dimension,
 {
@@ -298,8 +298,10 @@ impl<'a, A, S, D> From<&'a ArrayBase<S, D>> for ArrayView<'a, A, D>
     }
 }
 
+/// Implementation of `ArrayViewMut::from(&mut S)` where `S` is a slice or slicable.
+///
 /// Create a one-dimensional read-write array view of the data in `slice`.
-impl<'a, A, Slice: ?Sized> From<&'a mut Slice> for ArrayViewMut<'a, A, Ix>
+impl<'a, A, Slice: ?Sized> From<&'a mut Slice> for ArrayBase<ViewRepr<&'a mut A>, Ix>
     where Slice: AsMut<[A]>
 {
     fn from(slice: &'a mut Slice) -> Self {
@@ -310,7 +312,10 @@ impl<'a, A, Slice: ?Sized> From<&'a mut Slice> for ArrayViewMut<'a, A, Ix>
     }
 }
 
-impl<'a, A, S, D> From<&'a mut ArrayBase<S, D>> for ArrayViewMut<'a, A, D>
+/// Implementation of `ArrayViewMut::from(&mut A)` where `A` is an array.
+///
+/// Create a read-write array view of the array.
+impl<'a, A, S, D> From<&'a mut ArrayBase<S, D>> for ArrayBase<ViewRepr<&'a mut A>, D>
     where S: DataMut<Elem=A>,
           D: Dimension,
 {

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -318,3 +318,30 @@ impl<'a, A, S, D> From<&'a mut ArrayBase<S, D>> for ArrayViewMut<'a, A, D>
         array.view_mut()
     }
 }
+
+/// Argument conversion into an array view
+///
+/// The trait is parameterized over `A`, the element type, and `D`, the
+/// dimensionality of the array. `D` defaults to one-dimensional.
+///
+/// Use `.into()` to do the conversion.
+///
+/// ```
+/// use ndarray::AsArray;
+///
+/// fn sum<'a, V: AsArray<'a, f64>>(data: V) -> f64 {
+///     let array_view = data.into();
+///     array_view.scalar_sum()
+/// }
+///
+/// assert_eq!(
+///     sum(&[1., 2., 3.]),
+///     6.
+/// );
+///
+/// ```
+pub trait AsArray<'a, A: 'a, D = Ix> : Into<ArrayView<'a, A, D>> where D: Dimension { }
+impl<'a, A: 'a, D, T> AsArray<'a, A, D> for T
+    where T: Into<ArrayView<'a, A, D>>,
+          D: Dimension,
+{ }

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -277,11 +277,15 @@ impl<A, S, D> Decodable for ArrayBase<S, D>
 }
 
 
+/// Create a one-dimensional read-only array view of the data in `slice`.
 impl<'a, A, Slice: ?Sized> From<&'a Slice> for ArrayView<'a, A, Ix>
     where Slice: AsRef<[A]>
 {
     fn from(slice: &'a Slice) -> Self {
-        ArrayView::from_slice(slice.as_ref())
+        let xs = slice.as_ref();
+        unsafe {
+            Self::new_(xs.as_ptr(), xs.len(), 1)
+        }
     }
 }
 
@@ -294,11 +298,15 @@ impl<'a, A, S, D> From<&'a ArrayBase<S, D>> for ArrayView<'a, A, D>
     }
 }
 
+/// Create a one-dimensional read-write array view of the data in `slice`.
 impl<'a, A, Slice: ?Sized> From<&'a mut Slice> for ArrayViewMut<'a, A, Ix>
     where Slice: AsMut<[A]>
 {
     fn from(slice: &'a mut Slice) -> Self {
-        ArrayViewMut::from_slice(slice.as_mut())
+        let xs = slice.as_mut();
+        unsafe {
+            Self::new_(xs.as_mut_ptr(), xs.len(), 1)
+        }
     }
 }
 

--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -50,7 +50,7 @@ pub fn aview0<A>(x: &A) -> ArrayView<A, ()> {
 /// );
 /// ```
 pub fn aview1<A>(xs: &[A]) -> ArrayView<A, Ix> {
-    ArrayView::from_slice(xs)
+    ArrayView::from(xs)
 }
 
 /// Return a two-dimensional array view with elements borrowing `xs`.
@@ -86,7 +86,7 @@ pub fn aview2<A, V: FixedInitializer<Elem=A>>(xs: &[V]) -> ArrayView<A, (Ix, Ix)
 /// }
 /// ```
 pub fn aview_mut1<A>(xs: &mut [A]) -> ArrayViewMut<A, Ix> {
-    ArrayViewMut::from_slice(xs)
+    ArrayViewMut::from(xs)
 }
 
 /// Fixed-size array used for array initialization

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -265,7 +265,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// **Panics** if `axis` or `index` is out of bounds.
     ///
     /// ```
-    /// use ndarray::{arr1, arr2, Axis};
+    /// use ndarray::{arr2, ArrayView, Axis};
     ///
     /// let a = arr2(&[[1., 2.],    // -- axis 0, row 0
     ///                [3., 4.],    // -- axis 0, row 1
@@ -274,8 +274,8 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// //                \   axis 1, column 1
     /// //                 axis 1, column 0
     /// assert!(
-    ///     a.subview(Axis(0), 1) == arr1(&[3., 4.]) &&
-    ///     a.subview(Axis(1), 1) == arr1(&[2., 4., 6.])
+    ///     a.subview(Axis(0), 1) == ArrayView::from(&[3., 4.]) &&
+    ///     a.subview(Axis(1), 1) == ArrayView::from(&[2., 4., 6.])
     /// );
     /// ```
     pub fn subview(&self, axis: Axis, index: Ix)

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -10,19 +10,8 @@ use {
 /// # Methods for Array Views
 ///
 /// Methods for read-only array views `ArrayView<'a, A, D>`
-impl<'a, A> ArrayBase<ViewRepr<&'a A>, Ix> {
-    /// Create a one-dimensional read-only array view of the data in `xs`.
-    #[inline]
-    pub fn from_slice(xs: &'a [A]) -> Self {
-        ArrayView {
-            data: ViewRepr::new(),
-            ptr: xs.as_ptr() as *mut A,
-            dim: xs.len(),
-            strides: 1,
-        }
-    }
-}
-
+///
+/// Note that array views implement traits like `From`, `IntoIterator` too.
 impl<'a, A, D> ArrayBase<ViewRepr<&'a A>, D>
     where D: Dimension,
 {
@@ -99,19 +88,8 @@ impl<'a, A, D> ArrayBase<ViewRepr<&'a A>, D>
 }
 
 /// Methods for read-write array views `ArrayViewMut<'a, A, D>`
-impl<'a, A> ArrayBase<ViewRepr<&'a mut A>, Ix> {
-    /// Create a one-dimensional read-write array view of the data in `xs`.
-    #[inline]
-    pub fn from_slice(xs: &'a mut [A]) -> Self {
-        ArrayViewMut {
-            data: ViewRepr::new(),
-            ptr: xs.as_mut_ptr(),
-            dim: xs.len(),
-            strides: 1,
-        }
-    }
-}
-
+///
+/// Note that array views implement traits like `From`, `IntoIterator` too.
 impl<'a, A, D> ArrayBase<ViewRepr<&'a mut A>, D>
     where D: Dimension,
 {

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -3,15 +3,12 @@ use imp_prelude::*;
 use dimension::{self, stride_offset};
 use error::ShapeError;
 
-use {
-    ViewRepr,
-};
-
 /// # Methods for Array Views
 ///
 /// Methods for read-only array views `ArrayView<'a, A, D>`
 ///
-/// Note that array views implement traits like `From`, `IntoIterator` too.
+/// Note that array views implement traits like [`From`][f] and `IntoIterator` too.
+/// [f]: #method.from
 impl<'a, A, D> ArrayBase<ViewRepr<&'a A>, D>
     where D: Dimension,
 {
@@ -89,7 +86,9 @@ impl<'a, A, D> ArrayBase<ViewRepr<&'a A>, D>
 
 /// Methods for read-write array views `ArrayViewMut<'a, A, D>`
 ///
-/// Note that array views implement traits like `From`, `IntoIterator` too.
+/// Note that array views implement traits like [`From`][f] and `IntoIterator` too.
+///
+/// [f]: #method.from
 impl<'a, A, D> ArrayBase<ViewRepr<&'a mut A>, D>
     where D: Dimension,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ mod imp_prelude {
         DataMut,
         DataOwned,
         DataShared,
+        ViewRepr,
     };
     /// Wrapper type for private methods
     #[derive(Copy, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub use iterators::{
     AxisChunksIterMut,
 };
 
+pub use arraytraits::AsArray;
 pub use linalg::LinalgScalar;
 
 mod arraytraits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! - Iteration and most operations are efficient on arrays with contiguous
 //!   innermost dimension.
 //! - Array views can be used to slice and mutate any `[T]` data using
-//!   `ArrayView::from_slice` and `ArrayViewMut::from_slice`.
+//!   `ArrayView::from` and `ArrayViewMut::from`.
 //!
 //! ## Crate Status
 //!
@@ -414,11 +414,12 @@ pub type OwnedArray<A, D> = ArrayBase<Vec<A>, D>;
 
 /// A lightweight array view.
 ///
-/// `ArrayView` implements `IntoIterator`.
+/// See also [**Methods for Array Views**](struct.ArrayBase.html#methods-for-array-views).
 pub type ArrayView<'a, A, D> = ArrayBase<ViewRepr<&'a A>, D>;
 /// A lightweight read-write array view.
 ///
-/// `ArrayViewMut` implements `IntoIterator`.
+///
+/// See also [**Methods for Array Views**](struct.ArrayBase.html#methods-for-array-views).
 pub type ArrayViewMut<'a, A, D> = ArrayBase<ViewRepr<&'a mut A>, D>;
 
 /// Array view’s representation.


### PR DESCRIPTION
We solve the array input issue for `ArrayView::from` (see #21) by using `AsRef<[A]>`, which works well. The only real issue with AsRef is that `ArrayView::from` will accept strings and create a view from `&[u8]` based on that. Let's laugh and forget about that..

This replaces `ArrayView::from_slice` with just `ArrayView::from` instead.

Also add `AsArray` which is a simple restriction of the `Into<ArrayView<..>>` bound.

Fixes #21 