### PR TITLE
Change the axis indexing in dimension to use its own extension trait

### DIFF
--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -328,22 +328,49 @@ pub unsafe trait Dimension : Clone + Eq + Debug {
         offset
     }
 
-    #[doc(hidden)]
-    /// Get the dimension on `axis`.
+}
+
+/// Implementation-specific extensions to `Dimension`
+pub trait DimensionExt {
+// note: many extensions go in the main trait if they need to be special-
+// cased per dimension
+    /// Get the dimension at `axis`.
     ///
     /// *Panics* if `axis` is out of bounds.
     #[inline]
-    fn index(&self, axis: Axis) -> &Ix {
-        &self.slice()[axis.axis()]
+    fn axis(&self, axis: Axis) -> Ix;
+
+    /// Set the dimension at `axis`.
+    ///
+    /// *Panics* if `axis` is out of bounds.
+    #[inline]
+    fn set_axis(&mut self, axis: Axis, value: Ix);
+}
+
+impl<D> DimensionExt for D
+    where D: Dimension
+{
+    #[inline]
+    fn axis(&self, axis: Axis) -> Ix {
+        self.slice()[axis.axis()]
     }
 
-    #[doc(hidden)]
-    /// Get a mutable reference to the dimension on `axis`.
-    ///
-    /// *Panics* if `axis` is out of bounds.
     #[inline]
-    fn index_mut(&mut self, axis: Axis) -> &mut Ix {
-        &mut self.slice_mut()[axis.axis()]
+    fn set_axis(&mut self, axis: Axis, value: Ix) {
+        self.slice_mut()[axis.axis()] = value;
+    }
+}
+
+impl<'a> DimensionExt for [Ix]
+{
+    #[inline]
+    fn axis(&self, axis: Axis) -> Ix {
+        self[axis.axis()]
+    }
+
+    #[inline]
+    fn set_axis(&mut self, axis: Axis, value: Ix) {
+        self[axis.axis()] = value;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ mod imp_prelude {
         DataShared,
         ViewRepr,
     };
+    pub use dimension::DimensionExt;
     /// Wrapper type for private methods
     #[derive(Copy, Clone, Debug)]
     pub struct Priv<T>(pub T);

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -71,6 +71,8 @@ pub trait NdFloat :
 /// much float-relevant ndarray functionality as possible, including the traits
 /// needed for linear algebra (`Any`) and for *right hand side* scalar
 /// operations (`ScalarOperand`).
+///
+/// This trait can only be implemented by `f32` and `f64`.
 #[cfg(feature="assign_ops")]
 pub trait NdFloat :
     Float +

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -66,6 +66,8 @@ pub fn stack<'a, A, D>(axis: Axis, arrays: &[ArrayView<'a, A, D>])
 ///
 /// [1]: fn.stack.html
 ///
+/// ***Panics*** if the `stack` function would return an error.
+///
 /// ```
 /// #[macro_use(stack)]
 /// extern crate ndarray;

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -35,8 +35,8 @@ pub fn stack<'a, A, D>(axis: Axis, arrays: &[ArrayView<'a, A, D>])
     }
 
     let stacked_dim = arrays.iter()
-                            .fold(0, |acc, a| acc + a.dim().index(axis));
-    *res_dim.index_mut(axis) = stacked_dim;
+                            .fold(0, |acc, a| acc + a.shape().axis(axis));
+    res_dim.set_axis(axis, stacked_dim);
 
     // we can safely use uninitialized values here because they are Copy
     // and we will only ever write to them
@@ -50,7 +50,7 @@ pub fn stack<'a, A, D>(axis: Axis, arrays: &[ArrayView<'a, A, D>])
     {
         let mut assign_view = res.view_mut();
         for array in arrays {
-            let len = *array.dim().index(axis);
+            let len = array.shape().axis(axis);
             let (mut front, rest) = assign_view.split_at(axis, len);
             front.assign(array);
             assign_view = rest;

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -42,17 +42,3 @@ fn dyn_dimension()
     let z = OwnedArray::<f32, _>::zeros(dim.clone());
     assert_eq!(z.shape(), &dim[..]);
 }
-
-#[test]
-fn index_axis()
-{
-    assert_eq!(3.index(Axis(0)), &3);
-    assert_eq!((3, 2).index(Axis(1)), &2);
-
-    let mut dim = (2, 3, 3);
-    *dim.index_mut(Axis(2)) = 1;
-    assert_eq!(dim.index(Axis(2)), &1);
-
-    let a: OwnedArray<f64, (Ix, Ix, Ix)> = OwnedArray::zeros(dim);
-    assert_eq!(a.dim().index(Axis(1)), &3);
-}


### PR DESCRIPTION
The interface is now .axis(Axis) and .set_axis(Axis, Ix) and is defined
both on all Dimension as well as on [Ix].

Using it on &[Ix] allows by-reference usage, without having to clone the
dimension.