### PR TITLE
Implement an `arange` and `arange_step`constructors

### DIFF
--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -33,13 +33,22 @@ impl<S> ArrayBase<S, Ix>
         Self::from_vec(iterable.into_iter().collect())
     }
 
-    /// Create a one-dimensional array from inclusive interval
+    /// Create a one-dimensional array from the inclusive interval
     /// `[start, end]` with `n` elements. `F` must be a floating point type.
     pub fn linspace<F>(start: F, end: F, n: usize) -> ArrayBase<S, Ix>
         where S: Data<Elem=F>,
               F: libnum::Float,
     {
         Self::from_iter(linspace::linspace(start, end, n))
+    }
+
+    /// Create a one-dimensional array from the half-open interval
+    /// `[start, end)` with elements spaced by `step`. `F` must be a floating point type.
+    pub fn range<F>(start: F, end: F, step: F) -> ArrayBase<S, Ix>
+        where S: Data<Elem=F>,
+              F: libnum::Float,
+    {
+        Self::from_iter(linspace::range(start, end, step))
     }
 }
 
@@ -215,4 +224,3 @@ impl<S, A, D> ArrayBase<S, D>
     }
 
 }
-

--- a/src/linspace.rs
+++ b/src/linspace.rs
@@ -78,3 +78,26 @@ pub fn linspace<F>(a: F, b: F, n: usize) -> Linspace<F>
         len: n,
     }
 }
+
+/// Return an iterator of floats spaced by `step`.
+///
+/// The `Linspace` has `n` elements, where the first
+/// element is `a` and `b` is not included.
+/// Numerical reasons can result in `b` being included
+/// in the result.
+///
+/// Iterator element type is `F`, where `F` must be
+/// either `f32` or `f64`.
+#[inline]
+pub fn range<F>(a: F, b: F, step: F) -> Linspace<F>
+    where F: Float
+{
+    let len = b - a;
+    let steps = F::ceil(len / step);
+    Linspace {
+        start: a,
+        step: step,
+        len: steps.to_usize().unwrap(),
+        index: 0,
+    }
+}

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -712,3 +712,28 @@ fn deny_split_at_index_out_of_bounds() {
     let a = arr2(&[[1., 2.], [3., 4.]]);
     a.view().split_at(Axis(1), 3);
 }
+
+#[test]
+fn test_range() {
+    let a = OwnedArray::range(0., 5., 1.);
+    assert_eq!(a.len(), 5);
+    assert_eq!(a[0],  0.);
+    assert_eq!(a[4],  4.);
+
+    let b = OwnedArray::range(0., 2.2, 1.);
+    assert_eq!(b.len(), 3);
+    assert_eq!(b[0],  0.);
+    assert_eq!(b[2],  2.);
+
+    let c = OwnedArray::range(0., 5., 2.);
+    assert_eq!(c.len(), 3);
+    assert_eq!(c[0], 0.);
+    assert_eq!(c[1], 2.);
+    assert_eq!(c[2], 4.);
+
+    let d = OwnedArray::range(1.0, 2.2, 0.1);
+    assert_eq!(d.len(), 13);
+    assert_eq!(d[0], 1.);
+    assert_eq!(d[10], 2.);
+    assert_eq!(d[12], 2.2);
+}


### PR DESCRIPTION
I added `arange` and and `arange_step`, where `arange` is a specialisation with unit step length.
If you like it I can refactor a lot of internal uses of `linspace`.

There are some numeric problems in `arange_step`, but they exist equally in numpy:
```
In [1]: import numpy as np

In [2]: np.arange(1.0, 2.2, 0.1)
Out[2]:
array([ 1. ,  1.1,  1.2,  1.3,  1.4,  1.5,  1.6,  1.7,  1.8,  1.9,  2. ,
        2.1,  2.2])
```

Update: don't know why it shows all these commits, only the last one matters.