### PR TITLE
Switch to blas-sys and use BLAS in .mat_mul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
 language: rust
-sudo: false
+# use trusty for newer openblas
+sudo: required
+dist: trusty
 matrix:
   include:
     - rust: stable
+      env:
+       - FEATURES='test'
     - rust: beta
     - rust: nightly
       env:
-       - FEATURES='assign_ops rustc-serialize'
+       - FEATURES='test'
        - BENCH=1
 branches:
   only:
     - master
+addons:
+  apt:
+    packages:
+      - libopenblas-dev
 script:
   - |
       cargo build --verbose &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ blas-openblas-sys = [
 ]
 
 # This feature is used for testing
-all = ["blas-openblas-sys", "rustc-serialize"]
+test = ["blas-openblas-sys", "rustc-serialize"]
 
 [profile.release]
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,18 +35,24 @@ version = "0.3.16"
 optional = true
 
 [dependencies]
-rblas = { version = "0.0.13", optional = true }
+blas-sys = { version = "0.5", optional = true, default-features = false }
 
-#[dependencies.serde]
-#version = "0.4"
-#optional = true
+# rblas is deprecatedish
+rblas = { version = "0.0.13", optional = true }
 
 [features]
 
 assign_ops = []
 
+blas = ["blas-sys"]
+blas-openblas-sys = [
+    "blas",
+    "blas-sys/openblas",
+    "blas-sys/openblas-provider/system-openblas",
+]
+
 # This feature is used for testing
-all = ["assign_ops", "rblas", "rustc-serialize"]
+all = ["blas-openblas-sys", "rustc-serialize"]
 
 [profile.release]
 [profile.bench]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCCRATES = ndarray
 # deps to delete the generated docs
 RMDOCS =
 
-FEATURES = "assign_ops rustc-serialize rblas"
+FEATURES = "assign_ops rustc-serialize rblas blas"
 
 VERSIONS = $(patsubst %,target/VERS/%,$(DOCCRATES))
 

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -433,19 +433,52 @@ fn bench_col_iter(bench: &mut test::Bencher)
     bench.iter(|| for elt in it.clone() { black_box(elt); })
 }
 
-#[bench]
-fn bench_mat_mul_large(bench: &mut test::Bencher)
-{
-    let a = OwnedArray::<f32, _>::zeros((64, 64));
-    let b = OwnedArray::<f32, _>::zeros((64, 64));
-    let a = black_box(a.view());
-    let b = black_box(b.view());
-    bench.iter(|| a.mat_mul(&b));
+macro_rules! mat_mul {
+    ($modname:ident, $ty:ident, $(($name:ident, $m:expr, $n:expr, $k:expr))+) => {
+        mod $modname {
+            use test::{black_box, Bencher};
+            use ndarray::OwnedArray;
+            $(
+            #[bench]
+            fn $name(bench: &mut Bencher)
+            {
+                let a = OwnedArray::<$ty, _>::zeros(($m, $n));
+                let b = OwnedArray::<$ty, _>::zeros(($n, $k));
+                let a = black_box(a.view());
+                let b = black_box(b.view());
+                bench.iter(|| a.mat_mul(&b));
+            }
+            )+
+        }
+    }
+}
+
+mat_mul!{mat_mul_f32, f32,
+    (m004, 4, 4, 4)
+    (m007, 7, 7, 7)
+    (m008, 8, 8, 8)
+    (m012, 12, 12, 12)
+    (m016, 16, 16, 16)
+    (m032, 32, 32, 32)
+    (m064, 64, 64, 64)
+    (m127, 127, 127, 127)
+    (mix16x4, 32, 4, 32)
+    (mix32x2, 32, 2, 32)
+}
+
+mat_mul!{mat_mul_i32, i32,
+    (m004, 4, 4, 4)
+    (m007, 7, 7, 7)
+    (m008, 8, 8, 8)
+    (m012, 12, 12, 12)
+    (m016, 16, 16, 16)
+    (m032, 32, 32, 32)
+    (m064, 64, 64, 64)
 }
 
 #[cfg(feature = "rblas")]
 #[bench]
-fn bench_mat_mul_rblas_large(bench: &mut test::Bencher)
+fn bench_mat_mul_rblas_64(bench: &mut test::Bencher)
 {
     use rblas::Gemm;
     use rblas::attribute::Transpose;

--- a/src/arrayformat.rs
+++ b/src/arrayformat.rs
@@ -105,7 +105,10 @@ impl<'a, A: fmt::Debug, S, D: Dimension> fmt::Debug for ArrayBase<S, D>
     where S: Data<Elem=A>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format_array(self, f, <_>::fmt)
+        // Add extra information for Debug
+        try!(format_array(self, f, <_>::fmt));
+        try!(write!(f, " shape={:?}, strides={:?}", self.shape(), self.strides()));
+        Ok(())
     }
 }
 

--- a/src/blas.rs
+++ b/src/blas.rs
@@ -55,6 +55,7 @@
 //! I know), instead output its own error conditions, for example on dimension
 //! mismatch in a matrix multiplication.
 //!
+#![cfg_attr(has_deprecated, deprecated(note="`rblas` integration will move to its own crate."))]
 
 use std::os::raw::{c_int};
 

--- a/src/impl_linalg.rs
+++ b/src/impl_linalg.rs
@@ -281,14 +281,16 @@ fn mat_mul_impl<A, S>(lhs: &ArrayBase<S, (Ix, Ix)>, rhs: &ArrayBase<S, (Ix, Ix)>
                     CblasNoTrans => rhs_.dim().1,
                     _ => rhs_.dim().0,
                 };
+                // gemm is C ← αA^Op B^Op + βC
+                // Where Op is notrans/trans/conjtrans
                 unsafe {
                     blas_sys::c::$gemm(
                     CblasRowMajor,
                     lhs_trans,
                     rhs_trans,
-                    m as c_int, // m, rows of OP(a)
-                    n as c_int, // n, cols of OP(b)
-                    k as c_int, // k, cols of OP(a)
+                    m as c_int, // m, rows of Op(a)
+                    n as c_int, // n, cols of Op(b)
+                    k as c_int, // k, cols of Op(a)
                     1.0,                  // alpha
                     lhs_.ptr as *const _, // a
                     lhs_.strides()[0] as c_int, // lda

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,8 @@ extern crate rustc_serialize as serialize;
 
 #[cfg(feature = "rblas")]
 extern crate rblas;
+#[cfg(feature="blas")]
+extern crate blas_sys;
 
 extern crate itertools;
 extern crate num as libnum;

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -2,6 +2,7 @@
 
 #[macro_use]
 extern crate ndarray;
+extern crate itertools;
 
 use ndarray::{RcArray, S, Si,
     OwnedArray,
@@ -736,4 +737,27 @@ fn test_range() {
     assert_eq!(d[0], 1.);
     assert_eq!(d[10], 2.);
     assert_eq!(d[12], 2.2);
+}
+
+#[test]
+fn test_f_order() {
+    // Test that arrays are logically equal in every way,
+    // even if the underlying memory order is different
+    let c = arr2(&[[1, 2, 3],
+                   [4, 5, 6]]);
+    let mut f = OwnedArray::zeros_f(c.dim());
+    f.assign(&c);
+    assert_eq!(f, c);
+    assert_eq!(f.shape(), c.shape());
+    assert_eq!(c.strides(), &[3, 1]);
+    assert_eq!(f.strides(), &[1, 2]);
+    itertools::assert_equal(f.iter(), c.iter());
+    itertools::assert_equal(f.inner_iter(), c.inner_iter());
+    itertools::assert_equal(f.outer_iter(), c.outer_iter());
+    itertools::assert_equal(f.axis_iter(Axis(0)), c.axis_iter(Axis(0)));
+    itertools::assert_equal(f.axis_iter(Axis(1)), c.axis_iter(Axis(1)));
+
+    let dupc = &c + &c;
+    let dupf = &f + &f;
+    assert_eq!(dupc, dupf);
 }

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -7,25 +7,25 @@ use ndarray::{arr0, rcarr1, aview1};
 fn formatting()
 {
     let a = rcarr1::<f32>(&[1., 2., 3., 4.]);
-    assert_eq!(format!("{:?}", a),
+    assert_eq!(format!("{}", a),
                //"[   1,    2,    3,    4]");
                "[1, 2, 3, 4]");
-    assert_eq!(format!("{:4?}", a),
+    assert_eq!(format!("{:4}", a),
                "[   1,    2,    3,    4]");
     let a = a.reshape((4, 1, 1));
-    assert_eq!(format!("{:4?}", a),
+    assert_eq!(format!("{:4}", a),
                "[[[   1]],\n [[   2]],\n [[   3]],\n [[   4]]]");
 
     let a = a.reshape((2, 2));
     assert_eq!(format!("{}", a), 
                "[[1, 2],\n [3, 4]]");
-    assert_eq!(format!("{:?}", a), 
+    assert_eq!(format!("{}", a),
                "[[1, 2],\n [3, 4]]");
-    assert_eq!(format!("{:#4?}", a),
+    assert_eq!(format!("{:#4}", a),
                "[[   1,    2], [   3,    4]]");
 
     let b = arr0::<f32>(3.5);
-    assert_eq!(format!("{:?}", b),
+    assert_eq!(format!("{}", b),
                "3.5");
 
     let s = format!("{:.3e}", aview1::<f32>(&[1.1, 2.2, 33., 440.]));

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -5,6 +5,7 @@ use ndarray::RcArray;
 use ndarray::{arr0, rcarr1, rcarr2};
 use ndarray::{
     OwnedArray,
+    Ix,
 };
 
 use std::fmt;
@@ -130,4 +131,50 @@ fn dot_product() {
     let a = a.map(|f| *f as i32);
     let b = b.map(|f| *f as i32);
     assert_eq!(a.dot(&b), dot as i32);
+}
+
+fn range_mat(m: Ix, n: Ix) -> OwnedArray<f32, (Ix, Ix)> {
+    OwnedArray::linspace(0., (m * n - 1) as f32, m * n).into_shape((m, n)).unwrap()
+}
+
+#[cfg(has_assign)]
+#[test]
+fn mat_mul() {
+    let (m, n, k) = (8, 8, 8);
+    let a = range_mat(m, n);
+    let b = range_mat(n, k);
+    let mut b = b / 4.;
+    {
+        let mut c = b.column_mut(0);
+        c += 1.0;
+    }
+    let ab = a.mat_mul(&b);
+
+    let mut af = OwnedArray::zeros_f(a.dim());
+    let mut bf = OwnedArray::zeros_f(b.dim());
+    af.assign(&a);
+    bf.assign(&b);
+
+    assert_eq!(ab, a.mat_mul(&bf));
+    assert_eq!(ab, af.mat_mul(&b));
+    assert_eq!(ab, af.mat_mul(&bf));
+
+    let (m, n, k) = (10, 5, 11);
+    let a = range_mat(m, n);
+    let b = range_mat(n, k);
+    let mut b = b / 4.;
+    {
+        let mut c = b.column_mut(0);
+        c += 1.0;
+    }
+    let ab = a.mat_mul(&b);
+
+    let mut af = OwnedArray::zeros_f(a.dim());
+    let mut bf = OwnedArray::zeros_f(b.dim());
+    af.assign(&a);
+    bf.assign(&b);
+
+    assert_eq!(ab, a.mat_mul(&bf));
+    assert_eq!(ab, af.mat_mul(&b));
+    assert_eq!(ab, af.mat_mul(&bf));
 }

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -178,3 +178,22 @@ fn mat_mul() {
     assert_eq!(ab, af.mat_mul(&b));
     assert_eq!(ab, af.mat_mul(&bf));
 }
+
+// Check that matrix multiplication of contiguous matrices returns a
+// matrix with the same order 
+#[test]
+fn mat_mul_order() {
+    let (m, n, k) = (8, 8, 8);
+    let a = range_mat(m, n);
+    let b = range_mat(n, k);
+    let mut af = OwnedArray::zeros_f(a.dim());
+    let mut bf = OwnedArray::zeros_f(b.dim());
+    af.assign(&a);
+    bf.assign(&b);
+
+    let cc = a.mat_mul(&b);
+    let ff = af.mat_mul(&bf);
+
+    assert_eq!(cc.strides()[1], 1);
+    assert_eq!(ff.strides()[0], 1);
+}


### PR DESCRIPTION
Use transparent BLAS support in .mat_mul().

- Switch to using `blas-sys` and raw cblas function calls. The savings on overhead are noticeable compared to `rblas`'s trait object interface.
- `blas-sys` allows selecting which library provides blas.
- You must now use feature flag `blas` to use BLAS in .dot() and .mat_mul()
- This half-deprecates the feature flag `rblas`. If the rblas API is attractive, it can move to a separate crate.