### PR TITLE
Add .as_slice_memory_order(), improve scalar_sum, and fix bugs in from_vec_dim_stride

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -373,12 +373,12 @@ fn muladd_2d_f32_blas(bench: &mut test::Bencher)
 }
 
 #[bench]
-fn assign_scalar_2d_large(bench: &mut test::Bencher)
+fn assign_scalar_2d_corder(bench: &mut test::Bencher)
 {
     let a = OwnedArray::zeros((64, 64));
     let mut a = black_box(a);
     let s = 3.;
-    bench.iter(|| a.assign_scalar(&s))
+    bench.iter(move || a.assign_scalar(&s))
 }
 
 #[bench]
@@ -388,26 +388,43 @@ fn assign_scalar_2d_cutout(bench: &mut test::Bencher)
     let a = a.slice_mut(s![1..-1, 1..-1]);
     let mut a = black_box(a);
     let s = 3.;
-    bench.iter(|| a.assign_scalar(&s))
+    bench.iter(move || a.assign_scalar(&s))
 }
 
 #[bench]
-fn assign_scalar_2d_transposed_large(bench: &mut test::Bencher)
+fn assign_scalar_2d_forder(bench: &mut test::Bencher)
 {
     let mut a = OwnedArray::zeros((64, 64));
     a.swap_axes(0, 1);
     let mut a = black_box(a);
     let s = 3.;
-    bench.iter(|| a.assign_scalar(&s))
+    bench.iter(move || a.assign_scalar(&s))
 }
 
 #[bench]
-fn assign_scalar_2d_raw_large(bench: &mut test::Bencher)
+fn assign_zero_2d_corder(bench: &mut test::Bencher)
 {
     let a = OwnedArray::zeros((64, 64));
     let mut a = black_box(a);
-    let s = 3.;
-    bench.iter(|| for elt in a.raw_data_mut() { *elt = s; });
+    bench.iter(|| a.assign_scalar(&0.))
+}
+
+#[bench]
+fn assign_zero_2d_cutout(bench: &mut test::Bencher)
+{
+    let mut a = OwnedArray::zeros((66, 66));
+    let a = a.slice_mut(s![1..-1, 1..-1]);
+    let mut a = black_box(a);
+    bench.iter(|| a.assign_scalar(&0.))
+}
+
+#[bench]
+fn assign_zero_2d_forder(bench: &mut test::Bencher)
+{
+    let mut a = OwnedArray::zeros((64, 64));
+    a.swap_axes(0, 1);
+    let mut a = black_box(a);
+    bench.iter(|| a.assign_scalar(&0.))
 }
 
 #[bench]

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -48,7 +48,7 @@ fn sum_1d_raw(bench: &mut test::Bencher)
     let a = black_box(a);
     bench.iter(|| {
         let mut sum = 0;
-        for &elt in a.raw_data() {
+        for &elt in a.as_slice_memory_order().unwrap() {
             sum += elt;
         }
         sum
@@ -93,7 +93,7 @@ fn sum_2d_raw(bench: &mut test::Bencher)
     let a = black_box(a);
     bench.iter(|| {
         let mut sum = 0;
-        for &elt in a.raw_data() {
+        for &elt in a.as_slice_memory_order().unwrap() {
             sum += elt;
         }
         sum

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -585,10 +585,11 @@ unsafe impl Dimension for (Ix, Ix, Ix) {
             }
         }
         {
+            // stable sorting network for 3 elements
             let order = order.slice_mut();
             let strides = stride.slice_mut();
+            swap![strides, order, 1, 2];
             swap![strides, order, 0, 1];
-            swap![strides, order, 0, 2];
             swap![strides, order, 1, 2];
         }
         order

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -565,6 +565,27 @@ unsafe impl Dimension for (Ix, Ix, Ix) {
         let (s, t, u) = *strides;
         stride_offset(i, s) + stride_offset(j, t) + stride_offset(k, u)
     }
+
+    fn _fastest_varying_stride_order(&self) -> Self {
+        let mut stride = *self;
+        let mut order = (0, 1, 2);
+        macro_rules! swap {
+            ($stride:expr, $order:expr, $x:expr, $y:expr) => {
+                if $stride[$x] > $stride[$y] {
+                    $stride.swap($x, $y);
+                    $order.swap($x, $y);
+                }
+            }
+        }
+        {
+            let order = order.slice_mut();
+            let strides = stride.slice_mut();
+            swap![strides, order, 0, 1];
+            swap![strides, order, 0, 2];
+            swap![strides, order, 1, 2];
+        }
+        order
+    }
 }
 
 macro_rules! large_dim {

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -489,6 +489,7 @@ unsafe impl Dimension for (Ix, Ix) {
         (self.1, 1)
     }
 
+    #[inline]
     fn _fastest_varying_stride_order(&self) -> Self {
         if self.0 as Ixs <= self.1 as Ixs { (0, 1) } else { (1, 0) }
     }
@@ -573,6 +574,7 @@ unsafe impl Dimension for (Ix, Ix, Ix) {
         stride_offset(i, s) + stride_offset(j, t) + stride_offset(k, u)
     }
 
+    #[inline]
     fn _fastest_varying_stride_order(&self) -> Self {
         let mut stride = *self;
         let mut order = (0, 1, 2);

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -36,13 +36,17 @@ fn stride_is_positive(stride: Ix) -> bool {
 pub fn dim_stride_overlap<D: Dimension>(dim: &D, strides: &D) -> bool {
     let order = strides._fastest_varying_stride_order();
 
+    let dim = dim.slice();
+    let strides = strides.slice();
     let mut prev_offset = 1;
-    for &index in order.slice().iter() {
-        let s = strides.slice()[index];
-        if (s as isize) < prev_offset {
+    for &index in order.slice() {
+        let d = dim[index];
+        let s = strides[index];
+        // any stride is ok if dimension is 1
+        if d != 1 && (s as isize) < prev_offset {
             return true;
         }
-        prev_offset = stride_offset(dim.slice()[index], s);
+        prev_offset = stride_offset(d, s);
     }
     false
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,13 +87,13 @@ impl Error for ShapeError {
 
 impl fmt::Display for ShapeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
+        write!(f, "ShapeError/{:?}: {}", self.kind(), self.description())
     }
 }
 
 impl fmt::Debug for ShapeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ShapeError {:?}: {}", self.kind(), self.description())
+        write!(f, "ShapeError/{:?}: {}", self.kind(), self.description())
     }
 }
 

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -550,6 +550,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         if self.strides == defaults {
             return true;
         }
+        if self.ndim() == 1 { return false; }
         // check all dimensions -- a dimension of length 1 can have unequal strides
         for (&dim, (&s, &ds)) in zipsl(self.dim.slice(),
                                        zipsl(self.strides(), defaults.slice()))
@@ -563,13 +564,14 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
 
     fn is_contiguous(&self) -> bool {
         let defaults = self.dim.default_strides();
-        if self.ndim() == 0 || self.strides == defaults {
+        if self.strides == defaults {
             return true;
         }
+        if self.ndim() == 1 { return false; }
         let order = self.strides._fastest_varying_stride_order();
         let strides = self.strides.slice();
 
-        // if any stride is negative
+        // FIXME: Negative strides
         let dim = self.dim.slice();
         let mut cstride = 1;
         for &i in order.slice() {

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -584,11 +584,21 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         true
     }
 
+    /// Return a pointer to the first element in the array.
+    ///
+    /// Raw access to array elements needs to follow the strided indexing
+    /// scheme: an element at multi-index *I* in an array with strides *S* is 
+    /// located at offset
+    ///
+    /// *Σ<sub>0 ≤ k < d</sub> I<sub>k</sub> × S<sub>k</sub>*
+    ///
+    /// where *d* is `self.ndim()`.
     #[inline(always)]
     pub fn as_ptr(&self) -> *const A {
         self.ptr
     }
 
+    /// Return a mutable pointer to the first element in the array.
     #[inline(always)]
     pub fn as_mut_ptr(&mut self) -> *mut A
         where S: DataMut

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -878,6 +878,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// **Note:** Data memory order may not correspond to the index order
     /// of the array. Neither is the raw data slice is restricted to just the
     /// array’s view.<br>
+    #[cfg_attr(has_deprecated, deprecated(note="Use .as_slice_memory_order() instead"))]
     pub fn raw_data(&self) -> &[A]
         where S: DataOwned,
     {
@@ -892,6 +893,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// **Note:** The data is uniquely held and nonaliased
     /// while it is mutably borrowed.
+    #[cfg_attr(has_deprecated, deprecated(note="Use .as_slice_memory_order_mut() instead"))]
     pub fn raw_data_mut(&mut self) -> &mut [A]
         where S: DataOwned + DataMut,
     {

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -597,8 +597,11 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         self.ptr
     }
 
-    /// Return the array’s data as a slice, if it is contiguous and
-    /// the element order corresponds to the memory order. Return `None` otherwise.
+    /// Return the array’s data as a slice, if it is contiguous and in standard order.
+    /// Return `None` otherwise.
+    ///
+    /// If this function returns `Some(_)`, then the element order in the slice
+    /// corresponds to the logical order of the array’s elements.
     pub fn as_slice(&self) -> Option<&[A]> {
         if self.is_standard_layout() {
             unsafe {
@@ -609,8 +612,8 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         }
     }
 
-    /// Return the array’s data as a slice, if it is contiguous and
-    /// the element order corresponds to the memory order. Return `None` otherwise.
+    /// Return the array’s data as a slice, if it is contiguous and in standard order.
+    /// Return `None` otherwise.
     pub fn as_slice_mut(&mut self) -> Option<&mut [A]>
         where S: DataMut
     {
@@ -626,7 +629,12 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
 
     /// Return the array’s data as a slice if it is contiguous,
     /// return `None` otherwise.
-    pub fn as_slice_no_order(&self) -> Option<&[A]> {
+    ///
+    /// If this function returns `Some(_)`, then the elements in the slice
+    /// have whatever order the elements have in memory.
+    ///
+    /// Implementation notes: Does not yet support negatively strided arrays.
+    pub fn as_slice_memory_order(&self) -> Option<&[A]> {
         if self.is_contiguous() {
             unsafe {
                 Some(slice::from_raw_parts(self.ptr, self.len()))
@@ -638,7 +646,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
 
     /// Return the array’s data as a slice if it is contiguous,
     /// return `None` otherwise.
-    pub fn as_slice_mut_no_order(&mut self) -> Option<&mut [A]>
+    pub fn as_slice_memory_order_mut(&mut self) -> Option<&mut [A]>
         where S: DataMut
     {
         if self.is_contiguous() {

--- a/src/impl_numeric.rs
+++ b/src/impl_numeric.rs
@@ -62,7 +62,7 @@ impl<A, S, D> ArrayBase<S, D>
     pub fn scalar_sum(&self) -> A
         where A: Clone + Add<Output=A> + libnum::Zero,
     {
-        if let Some(slc) = self.as_slice() {
+        if let Some(slc) = self.as_slice_no_order() {
             return numeric_util::unrolled_sum(slc);
         }
         let mut sum = A::zero();

--- a/src/impl_numeric.rs
+++ b/src/impl_numeric.rs
@@ -62,7 +62,7 @@ impl<A, S, D> ArrayBase<S, D>
     pub fn scalar_sum(&self) -> A
         where A: Clone + Add<Output=A> + libnum::Zero,
     {
-        if let Some(slc) = self.as_slice_no_order() {
+        if let Some(slc) = self.as_slice_memory_order() {
             return numeric_util::unrolled_sum(slc);
         }
         let mut sum = A::zero();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,7 +506,7 @@ impl<A, S, D> ArrayBase<S, D>
         where S: DataMut,
               F: FnMut(&mut A)
     {
-        if let Some(slc) = self.as_slice_mut() {
+        if let Some(slc) = self.as_slice_mut_no_order() {
             for elt in slc {
                 f(elt);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,7 +506,7 @@ impl<A, S, D> ArrayBase<S, D>
         where S: DataMut,
               F: FnMut(&mut A)
     {
-        if let Some(slc) = self.as_slice_mut_no_order() {
+        if let Some(slc) = self.as_slice_memory_order_mut() {
             for elt in slc {
                 f(elt);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,10 +237,13 @@ pub type Ixs = isize;
 /// for element indices in `.get()` and `array[index]`. The dimension type `Vec<Ix>`
 /// allows a dynamic number of axes.
 ///
-/// The default memory order of an array is *row major* order, where each
-/// row is contiguous in memory.
-/// A *column major* (a.k.a. fortran) memory order array has
+/// The default memory order of an array is *row major* order (a.k.a ”c” order),
+/// where each row is contiguous in memory.
+/// A *column major* (a.k.a. “f” or fortran) memory order array has
 /// columns (or, in general, the outermost axis) with contiguous elements.
+///
+/// The logical order of any array’s elements is the row major order.
+/// The iterators `.iter(), .iter_mut()` always adhere to this order, for example.
 ///
 /// ## Slicing
 ///

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -54,7 +54,7 @@ impl<T> LinalgScalar for T
 pub trait NdFloat :
     Float +
     fmt::Display + fmt::Debug + fmt::LowerExp + fmt::UpperExp +
-    ScalarOperand + LinalgScalar
+    ScalarOperand + LinalgScalar + Send + Sync
 { }
 
 /// Floating-point element types `f32` and `f64`.
@@ -70,7 +70,7 @@ pub trait NdFloat :
     Float +
     AddAssign + SubAssign + MulAssign + DivAssign + RemAssign +
     fmt::Display + fmt::Debug + fmt::LowerExp + fmt::UpperExp +
-    ScalarOperand + LinalgScalar
+    ScalarOperand + LinalgScalar + Send + Sync
 { }
 
 impl NdFloat for f32 { }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -7,7 +7,9 @@ extern crate itertools;
 use ndarray::{RcArray, S, Si,
     OwnedArray,
 };
-use ndarray::{arr0, arr1, arr2, arr3,
+use ndarray::{
+    rcarr2,
+    arr0, arr1, arr2, arr3,
     aview0,
     aview1,
     aview2,
@@ -244,8 +246,8 @@ fn swapaxes()
     assert_eq!(a, b);
     a.swap_axes(1, 1);
     assert_eq!(a, b);
-    assert!(a.raw_data() == [1., 2., 3., 4.]);
-    assert!(b.raw_data() == [1., 3., 2., 4.]);
+    assert_eq!(a.as_slice_memory_order(), Some(&[1., 2., 3., 4.][..]));
+    assert_eq!(b.as_slice_memory_order(), Some(&[1., 3., 2., 4.][..]));
 }
 
 #[test]
@@ -380,11 +382,12 @@ fn map1()
 }
 
 #[test]
-fn raw_data_mut()
+fn as_slice_memory_order()
 {
-    let a = arr2(&[[1., 2.], [3., 4.0f32]]);
+    // test that mutation breaks sharing
+    let a = rcarr2(&[[1., 2.], [3., 4.0f32]]);
     let mut b = a.clone();
-    for elt in b.raw_data_mut() {
+    for elt in b.as_slice_memory_order_mut().unwrap() {
         *elt = 0.;
     }
     assert!(a != b, "{:?} != {:?}", a, b);

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -512,6 +512,25 @@ fn from_vec_dim_stride_2d_6() {
 }
 
 #[test]
+fn from_vec_dim_stride_2d_7() {
+    // empty arrays can have 0 strides
+    let a: [f32; 0] = [];
+    // [[]] shape=[4, 0], strides=[0, 1]
+    let d = (4, 0);
+    let s = (0, 1);
+    assert_matches!(OwnedArray::from_vec_dim_stride(d, s, a.to_vec()), Ok(_));
+}
+
+#[test]
+fn from_vec_dim_stride_2d_8() {
+    // strides must be strictly positive (nonzero)
+    let a = [1.];
+    let d = (1, 1);
+    let s = (0, 1);
+    assert_matches!(OwnedArray::from_vec_dim_stride(d, s, a.to_vec()), Err(_));
+}
+
+#[test]
 fn from_vec_dim_stride_2d_rejects() {
     let two = [1., 2.];
     let d = (2, 2);

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -500,6 +500,18 @@ fn from_vec_dim_stride_2d_5() {
 }
 
 #[test]
+fn from_vec_dim_stride_2d_6() {
+    let a = [1., 2., 3., 4., 5., 6.];
+    let d = (2, 1, 1);
+    let s = (2, 2, 1);
+    assert_matches!(OwnedArray::from_vec_dim_stride(d, s, a.to_vec()), Ok(_));
+
+    let d = (1, 2, 1);
+    let s = (2, 2, 1);
+    assert_matches!(OwnedArray::from_vec_dim_stride(d, s, a.to_vec()), Ok(_));
+}
+
+#[test]
 fn from_vec_dim_stride_2d_rejects() {
     let two = [1., 2.];
     let d = (2, 2);

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -761,3 +761,27 @@ fn test_f_order() {
     let dupf = &f + &f;
     assert_eq!(dupc, dupf);
 }
+
+#[test]
+fn test_contiguous() {
+    let c = arr3(&[[[1, 2, 3],
+                    [4, 5, 6]],
+                   [[4, 5, 6],
+                    [7, 7, 7]]]);
+    assert!(c.is_standard_layout());
+    assert!(c.as_slice_no_order().is_some());
+    let v = c.slice(s![.., 0..1, ..]);
+    assert!(!v.is_standard_layout());
+    assert!(!v.as_slice_no_order().is_some());
+
+    let v = c.slice(s![1..2, .., ..]);
+    assert!(v.is_standard_layout());
+    assert!(v.as_slice_no_order().is_some());
+    let v = v.reversed_axes();
+    assert!(!v.is_standard_layout());
+    assert!(v.as_slice_no_order().is_some());
+    let mut v = v.reversed_axes();
+    v.swap_axes(1, 2);
+    assert!(!v.is_standard_layout());
+    assert!(v.as_slice_no_order().is_some());
+}

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -887,19 +887,19 @@ fn test_contiguous() {
                    [[4, 5, 6],
                     [7, 7, 7]]]);
     assert!(c.is_standard_layout());
-    assert!(c.as_slice_no_order().is_some());
+    assert!(c.as_slice_memory_order().is_some());
     let v = c.slice(s![.., 0..1, ..]);
     assert!(!v.is_standard_layout());
-    assert!(!v.as_slice_no_order().is_some());
+    assert!(!v.as_slice_memory_order().is_some());
 
     let v = c.slice(s![1..2, .., ..]);
     assert!(v.is_standard_layout());
-    assert!(v.as_slice_no_order().is_some());
+    assert!(v.as_slice_memory_order().is_some());
     let v = v.reversed_axes();
     assert!(!v.is_standard_layout());
-    assert!(v.as_slice_no_order().is_some());
+    assert!(v.as_slice_memory_order().is_some());
     let mut v = v.reversed_axes();
     v.swap_axes(1, 2);
     assert!(!v.is_standard_layout());
-    assert!(v.as_slice_no_order().is_some());
+    assert!(v.as_slice_memory_order().is_some());
 }

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -6,6 +6,7 @@ use ndarray::{
     RemoveAxis,
     arr2,
     Axis,
+    Dimension,
 };
 
 #[test]
@@ -40,3 +41,15 @@ fn dyn_dimension()
     let z = OwnedArray::<f32, _>::zeros(dim.clone());
     assert_eq!(z.shape(), &dim[..]);
 }
+
+#[test]
+fn fastest_varying_order() {
+    let strides = (2, 8, 4, 1);
+    let order = strides._fastest_varying_stride_order();
+    assert_eq!(order.slice(), &[3, 0, 2, 1]);
+
+    assert_eq!((1, 3)._fastest_varying_stride_order(), (0, 1));
+    assert_eq!((7, 2)._fastest_varying_stride_order(), (1, 0));
+    assert_eq!((6, 1, 3)._fastest_varying_stride_order(), (1, 2, 0));
+}
+

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -51,5 +51,11 @@ fn fastest_varying_order() {
     assert_eq!((1, 3)._fastest_varying_stride_order(), (0, 1));
     assert_eq!((7, 2)._fastest_varying_stride_order(), (1, 0));
     assert_eq!((6, 1, 3)._fastest_varying_stride_order(), (1, 2, 0));
+
+    // it's important that it produces distinct indices. Prefer the stable order
+    // where 0 is before 1 when they are equal.
+    assert_eq!((2, 2)._fastest_varying_stride_order(), (0, 1));
+    assert_eq!((2, 2, 1)._fastest_varying_stride_order(), (2, 0, 1));
+    assert_eq!((2, 2, 3, 1, 2)._fastest_varying_stride_order(), (3, 0, 1, 4, 2));
 }
 


### PR DESCRIPTION
- Add .as_slice_memory_order(), .as_slice_memory_order_mut()
- Fix bugs in from_vec_dim_stride that relate to axes of length 0 or 1.
- Misc bonus changes: Add Send + Sync to NdFloat, Improve Display for ShapeError.

Part of #138 
Fixes #58 
Fixes #144 

Using [cargo-benchcmp](https://github.com/BurntSushi/cargo-benchcmp) to review performance changes

The true improvement here is assign scalar for the transposed (f-order) case and scalar_sum should improve the same way. Most important was though to validate that there are no perf regressions. Everything looks like it's the same or within error.

```
name                               assign_scalar_before2 ns/iter  assign_scalar_after2 ns/iter    diff ns/iter   diff %
assign_scalar_2d_cutout            1,640                          1,687                                     47    2.87%
assign_scalar_2d_large             1,595                          1,593                                     -2   -0.13%
assign_scalar_2d_transposed_large  3,618                          1,644                                 -1,974  -54.56%
```

```
name                       add_before3 ns/iter  add_after2 ns/iter    diff ns/iter   diff %
add_2d_0_to_2_iadd_scalar  476                  399                            -77  -16.18%
add_2d_assign_ops          626                  616                            -10   -1.60%
add_2d_broadcast_0_to_2    476                  400                            -76  -15.97%
add_2d_broadcast_1_to_2    646                  652                              6    0.93%
add_2d_cutout              1,254                1,257                            3    0.24%
add_2d_f32_regular         632                  637                              5    0.79%
add_2d_regular             625                  628                              3    0.48%
add_2d_transposed          3,341                2,906                         -435  -13.02%
muladd_2d_f32_regular      699                  700                              1    0.14%
```

```
name                        scalar_sum_before4 ns/iter  scalar_sum_after5 ns/iter    diff ns/iter  diff %
scalar_sum_2d_cutout        745                         732                                   -13  -1.74%
scalar_sum_2d_float         570                         578                                     8   1.40%
scalar_sum_2d_float_cutout  839                         838                                    -1  -0.12%
scalar_sum_2d_regular       251                         253                                     2   0.80%
```