### PR TITLE
Use .as_slice_memory_order in .to_owned() and .map()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
       cargo test --verbose &&
       ([ -z "$FEATURES" ] || cargo build --verbose --features "$FEATURES") &&
       ([ -z "$FEATURES" ] || cargo test --verbose --features "$FEATURES") &&
-      ([ "$BENCH" != 1 ] || cargo bench --verbose --features "$FEATURES")
+      ([ "$BENCH" != 1 ] || cargo bench --no-run --verbose --features "$FEATURES")

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -888,6 +888,7 @@ send_sync_read_write!(AxisChunksIterMut);
 /// to deliver exactly as many items as it said it would.
 pub unsafe trait TrustedIterator { }
 
+use std::slice;
 use std::iter;
 use linspace::Linspace;
 
@@ -895,6 +896,7 @@ unsafe impl<F> TrustedIterator for Linspace<F> { }
 unsafe impl<'a, A, D> TrustedIterator for Elements<'a, A, D> { }
 unsafe impl<I, F> TrustedIterator for iter::Map<I, F>
     where I: TrustedIterator { }
+unsafe impl<'a, A> TrustedIterator for slice::Iter<'a, A> { }
 
 
 /// Like Iterator::collect, but only for trusted length iterators

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -884,6 +884,32 @@ fn test_f_order() {
 }
 
 #[test]
+fn to_owned_memory_order() {
+    // check that .to_owned() makes f-contiguous arrays out of f-contiguous
+    // input.
+    let c = arr2(&[[1, 2, 3],
+                   [4, 5, 6]]);
+    let mut f = c.view();
+    f.swap_axes(0, 1);
+    let fo = f.to_owned();
+    assert_eq!(f, fo);
+    assert_eq!(f.strides(), fo.strides());
+}
+
+#[test]
+fn map_memory_order() {
+    let a = arr3(&[[[1, 2, 3],
+                    [4, 5, 6]],
+                   [[7, 8, 9],
+                    [0, -1, -2]]]);
+    let mut v = a.view();
+    v.swap_axes(0, 1);
+    let amap = v.map(|x| *x >= 3);
+    assert_eq!(amap.dim(), v.dim());
+    assert_eq!(amap.strides(), v.strides());
+}
+
+#[test]
 fn test_contiguous() {
     let c = arr3(&[[[1, 2, 3],
                     [4, 5, 6]],


### PR DESCRIPTION
Part of #138 