### PR TITLE
Use counted loop in unordered_foreach_mut

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1041,8 +1041,9 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         where F: FnMut(B, &'a A) -> B, A: 'a
     {
         if let Some(slc) = self.as_slice() {
-            for elt in slc {
-                init = f(init, elt);
+            // FIXME: Use for loop when slice iterator is perf is restored
+            for i in 0..slc.len() {
+                init = f(init, &slc[i]);
             }
             return init;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,12 +510,20 @@ impl<A, S, D> ArrayBase<S, D>
               F: FnMut(&mut A)
     {
         if let Some(slc) = self.as_slice_memory_order_mut() {
-            for elt in slc {
-                f(elt);
+            // FIXME: Use for loop when slice iterator is perf is restored
+            for i in 0..slc.len() {
+                f(&mut slc[i]);
             }
             return;
         }
-        for row in self.inner_iter_mut() {
+        for mut row in self.inner_iter_mut() {
+            if let Some(slc) = row.as_slice_mut() {
+                // FIXME: Use for loop when slice iterator is perf is restored
+                for i in 0..slc.len() {
+                    f(&mut slc[i]);
+                }
+                continue;
+            }
             for elt in row {
                 f(elt);
             }


### PR DESCRIPTION
Use counted loop in unordered_foreach_mut

This improves the generated code for the inner loop we use for
.assign_scalar() and other array operations with a single scalar.

The old code would generate something that looked like it assumed the
element being written to and the iterator's pointer could alias another. This
new version is unrolled and vectorized to a larger degree, but it does
still not produce memset for some inputs like rust could do in january 2016.

```
name                     before ns/iter  after ns/iter    diff ns/iter   diff %
assign_scalar_2d_corder  1,631           868                      -763  -46.78%
assign_scalar_2d_cutout  1,704           1,332                    -372  -21.83%
assign_scalar_2d_forder  1,628           869                      -759  -46.62%
assign_zero_2d_corder    1,602           855                      -747  -46.63%
assign_zero_2d_cutout    1,703           1,335                    -368  -21.61%
assign_zero_2d_forder    1,618           858                      -760  -46.97%

before: Using the slice iterator
after: using indexed loop.
```