### PR TITLE
Methods .mapv(), .mapv_into(), .apply(), .applyv(), .visit()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,16 +53,20 @@ Status and Lookout
 
 - Performance status:
 
-  + Arithmetic involving arrays of contiguous inner dimension optimizes very well.
-  + ``.fold()`` and ``.zip_mut_with()`` are the most efficient ways to
+  + Performance of an operation depends on the memory layout of the array
+    or array view. Especially if it's a binary operation, which
+    needs matching memory layout to be efficient (with some exceptions).
+  + Arithmetic optimizes very well if the arrays are have contiguous inner dimension.
+  + The callback based methods like ``.mapv()``, ``.applyv()`` and
+    ``.zip_mut_with()`` are the most efficient ways to
     perform single traversal and lock step traversal respectively.
-  + ``.iter()`` and ``.iter_mut()`` are efficient for contiguous arrays.
+  + ``.iter()`` is efficient for c-contiguous arrays.
   + Can use BLAS in some operations (``dot`` and ``mat_mul``).
 
 Crate Feature Flags
 -------------------
 
-The following crate feature flags are available. The are configured in
+The following crate feature flags are available. They are configured in
 your `Cargo.toml`.
 
 - ``assign_ops``

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -117,17 +117,6 @@ fn iter_sum_2d_cutout(bench: &mut test::Bencher)
 }
 
 #[bench]
-fn iter_sum_2d_cutout_fold(bench: &mut test::Bencher)
-{
-    let a = OwnedArray::<i32, _>::zeros((66, 66));
-    let av = a.slice(s![1..-1, 1..-1]);
-    let a = black_box(av);
-    bench.iter(|| {
-        a.fold(0, |acc, elt| acc + *elt)
-    });
-}
-
-#[bench]
 fn iter_sum_2d_cutout_by_row(bench: &mut test::Bencher)
 {
     let a = OwnedArray::<i32, _>::zeros((66, 66));

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -12,6 +12,7 @@ use rblas::matrix::Matrix;
 use ndarray::{
     OwnedArray,
     Axis,
+    Ix,
 };
 use ndarray::{arr0, arr1, arr2};
 
@@ -642,9 +643,33 @@ fn dot_extended(bench: &mut test::Bencher) {
     })
 }
 
+const MEAN_SUM_N: usize = 127;
+
+fn range_mat(m: Ix, n: Ix) -> OwnedArray<f32, (Ix, Ix)> {
+    assert!(m * n != 0);
+    OwnedArray::linspace(0., (m * n - 1) as f32, m * n).into_shape((m, n)).unwrap()
+}
+
 #[bench]
-fn means(bench: &mut test::Bencher) {
-    let a = OwnedArray::from_iter(0..100_000i64);
-    let a = a.into_shape((100, 1000)).unwrap();
+fn mean_axis0(bench: &mut test::Bencher) {
+    let a = range_mat(MEAN_SUM_N, MEAN_SUM_N);
     bench.iter(|| a.mean(Axis(0)));
+}
+
+#[bench]
+fn mean_axis1(bench: &mut test::Bencher) {
+    let a = range_mat(MEAN_SUM_N, MEAN_SUM_N);
+    bench.iter(|| a.mean(Axis(1)));
+}
+
+#[bench]
+fn sum_axis0(bench: &mut test::Bencher) {
+    let a = range_mat(MEAN_SUM_N, MEAN_SUM_N);
+    bench.iter(|| a.sum(Axis(0)));
+}
+
+#[bench]
+fn sum_axis1(bench: &mut test::Bencher) {
+    let a = range_mat(MEAN_SUM_N, MEAN_SUM_N);
+    bench.iter(|| a.sum(Axis(1)));
 }

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -913,6 +913,8 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         self.view().reversed_axes()
     }
 
+    /// ***Deprecated: Use .as_slice_memory_order() instead.***
+    ///
     /// Return a slice of the array’s backing data in memory order.
     ///
     /// **Note:** Data memory order may not correspond to the index order
@@ -925,6 +927,8 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         self.data.slice()
     }
 
+    /// ***Deprecated: Use .as_slice_memory_order_mut() instead.***
+    ///
     /// Return a mutable slice of the array’s backing data in memory order.
     ///
     /// **Note:** Data memory order may not correspond to the index order

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -129,7 +129,6 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn iter_mut(&mut self) -> ElementsMut<A, D>
         where S: DataMut,
     {
-        self.ensure_unique();
         self.view_mut().into_iter_()
     }
 
@@ -229,8 +228,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         where S: DataMut,
               I: NdIndex<Dim=D>,
     {
-        self.ensure_unique();
-        let ptr = self.ptr;
+        let ptr = self.as_mut_ptr();
         index.index_checked(&self.dim, &self.strides)
              .map(move |offset| unsafe { &mut *ptr.offset(offset) })
     }

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1079,8 +1079,12 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         }
     }
 
+    /// ***Deprecated: Will be removed because it dictates a specific order.***
+    ///
     /// Traverse the array elements in order and apply a fold,
     /// returning the resulting value.
+    #[cfg_attr(has_deprecated, deprecated(note=
+      "Will be removed because it dictates a specific order"))]
     pub fn fold<'a, F, B>(&'a self, mut init: B, mut f: F) -> B
         where F: FnMut(B, &'a A) -> B, A: 'a
     {

--- a/src/impl_numeric.rs
+++ b/src/impl_numeric.rs
@@ -70,7 +70,7 @@ impl<A, S, D> ArrayBase<S, D>
             if let Some(slc) = row.as_slice() {
                 sum = sum + numeric_util::unrolled_sum(slc);
             } else {
-                sum = sum + row.fold(A::zero(), |acc, elt| acc + elt.clone());
+                sum = sum + row.iter().fold(A::zero(), |acc, elt| acc + elt.clone());
             }
         }
         sum

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,15 +43,19 @@
 //!     *will be deprecated* when Rust supports `+=` and similar in Rust 1.8.
 //!   + We try to introduce more static checking gradually.
 //! - Performance status:
-//!   + Arithmetic involving arrays of contiguous inner dimension optimizes very well.
-//!   + `.fold()` and `.zip_mut_with()` are the most efficient ways to
+//!   + Performance of an operation depends on the memory layout of the array
+//!     or array view. Especially if it's a binary operation, which
+//!     needs matching memory layout to be efficient (with some exceptions).
+//!   + Arithmetic optimizes very well if the arrays are have contiguous inner dimension.
+//!   + The callback based methods like ``.mapv()``, ``.applyv()`` and
+//!     ``.zip_mut_with()`` are the most efficient ways to
 //!     perform single traversal and lock step traversal respectively.
-//!   + `.iter()` and `.iter_mut()` are efficient for contiguous arrays.
+//!   + ``.iter()`` is efficient for c-contiguous arrays.
 //!   + Can use BLAS in some operations (`dot` and `mat_mul`).
 //!
 //! ## Crate Feature Flags
 //!
-//! The following crate feature flags are available. The are configured in your
+//! The following crate feature flags are available. They are configured in your
 //! `Cargo.toml`.
 //!
 //! - `assign_ops`


### PR DESCRIPTION
Fixes #58 
Fixes #153

I did experiment with a trait to unify the map and mapv case into a single method, and while it worked, it also introduced type inference ambiguities everywhere, so it was so much less useful.