### PR TITLE
Update blas-sys and openblas-provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ optional = true
 
 [dependencies]
 # Use via the `blas` crate feature!
-blas-sys = { version = "0.5", optional = true, default-features = false }
-openblas-provider = { version = "0.3", optional = true, default-features = false }
+blas-sys = { version = "0.6", optional = true, default-features = false }
+openblas-provider = { version = "0.4", optional = true, default-features = false }
 
 # deprecated! use ndarray-rblas instead
 rblas = { version = "0.0.13", optional = true }
@@ -50,7 +50,7 @@ blas = ["blas-sys"]
 blas-openblas-sys = [
     "blas",
     "blas-sys/openblas",
-    "openblas-provider/system-openblas",
+    "openblas-provider/system",
 ]
 
 # This feature is used for testing


### PR DESCRIPTION
I have updated `openblas-provider` to compile OpenBLAS v0.2.17, which was released five days ago.