### PR TITLE
Use fallback matrix multiplication for negative/zero strides in mat_mul

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -284,8 +284,7 @@ fn add_2d_broadcast_0_to_2(bench: &mut test::Bencher)
 
 #[bench]
 fn scalar_toowned(bench: &mut test::Bencher) {
-    let mut a = OwnedArray::<f32, _>::zeros((64, 64));
-    let n = 1.;
+    let a = OwnedArray::<f32, _>::zeros((64, 64));
     bench.iter(|| {
         a.to_owned()
     });
@@ -293,7 +292,7 @@ fn scalar_toowned(bench: &mut test::Bencher) {
 
 #[bench]
 fn scalar_add_1(bench: &mut test::Bencher) {
-    let mut a = OwnedArray::<f32, _>::zeros((64, 64));
+    let a = OwnedArray::<f32, _>::zeros((64, 64));
     let n = 1.;
     bench.iter(|| {
         &a + n
@@ -302,7 +301,7 @@ fn scalar_add_1(bench: &mut test::Bencher) {
 
 #[bench]
 fn scalar_add_2(bench: &mut test::Bencher) {
-    let mut a = OwnedArray::<f32, _>::zeros((64, 64));
+    let a = OwnedArray::<f32, _>::zeros((64, 64));
     let n = 1.;
     bench.iter(|| {
         n + &a
@@ -311,7 +310,7 @@ fn scalar_add_2(bench: &mut test::Bencher) {
 
 #[bench]
 fn scalar_sub_1(bench: &mut test::Bencher) {
-    let mut a = OwnedArray::<f32, _>::zeros((64, 64));
+    let a = OwnedArray::<f32, _>::zeros((64, 64));
     let n = 1.;
     bench.iter(|| {
         &a - n
@@ -320,7 +319,7 @@ fn scalar_sub_1(bench: &mut test::Bencher) {
 
 #[bench]
 fn scalar_sub_2(bench: &mut test::Bencher) {
-    let mut a = OwnedArray::<f32, _>::zeros((64, 64));
+    let a = OwnedArray::<f32, _>::zeros((64, 64));
     let n = 1.;
     bench.iter(|| {
         n - &a

--- a/src/impl_linalg.rs
+++ b/src/impl_linalg.rs
@@ -457,6 +457,9 @@ fn blas_row_major_2d<A, S>(a: &ArrayBase<S, (Ix, Ix)>) -> bool
     if s1 != 1 {
         return false;
     }
+    if s0 < 1 || s1 < 1 {
+        return false;
+    }
     if (s0 > blas_index::max_value() as isize || s0 < blas_index::min_value() as isize) ||
         (s1 > blas_index::max_value() as isize || s1 < blas_index::min_value() as isize)
     {

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -1,4 +1,4 @@
-extern crate ndarray;
+#[macro_use(s)] extern crate ndarray;
 extern crate num as libnum;
 
 use ndarray::RcArray;
@@ -215,6 +215,42 @@ fn mat_mul_order() {
 
     assert_eq!(cc.strides()[1], 1);
     assert_eq!(ff.strides()[0], 1);
+}
+
+// Check that matrix multiplication
+// supports broadcast arrays.
+#[test]
+fn mat_mul_broadcast() {
+    let (m, n, k) = (16, 16, 16);
+    let a = range_mat(m, n);
+    let x1 = 1.;
+    let x = OwnedArray::from_vec(vec![x1]);
+    let b0 = x.broadcast((n, k)).unwrap();
+    let b1 = OwnedArray::from_elem(n, x1);
+    let b1 = b1.broadcast((n, k)).unwrap();
+    let b2 = OwnedArray::from_elem((n, k), x1);
+
+    let c2 = a.mat_mul(&b2);
+    let c1 = a.mat_mul(&b1);
+    let c0 = a.mat_mul(&b0);
+    assert_eq!(c2, c1);
+    assert_eq!(c2, c0);
+}
+
+// Check that matrix multiplication supports reversed axes
+#[test]
+fn mat_mul_rev() {
+    let (m, n, k) = (16, 16, 16);
+    let a = range_mat(m, n);
+    let b = range_mat(n, k);
+    let mut rev = OwnedArray::zeros(b.dim());
+    let mut rev = rev.slice_mut(s![..;-1, ..]);
+    rev.assign(&b);
+    println!("{:.?}", rev);
+
+    let c1 = a.mat_mul(&b);
+    let c2 = a.mat_mul(&rev);
+    assert_eq!(c1, c2);
 }
 
 #[test]


### PR DESCRIPTION
This fixes a bug when feature `blas` was used; mat_mul would not multiply zero/negative stride matrices correctly.