### PR TITLE
Add generalized mat mul function

### DIFF
--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -10,5 +10,6 @@
 //! Linear algebra.
 
 pub use self::impl_linalg::Dot;
+pub use self::impl_linalg::general_mat_mul;
 
 mod impl_linalg;


### PR DESCRIPTION
This allows expressing C ← α A B + β C, i.e matrix multiplication into an existing array, paired with scaling of either of the operands.