### PR TITLE
Add a prelude module to ndarray

### DIFF
--- a/examples/life.rs
+++ b/examples/life.rs
@@ -1,10 +1,7 @@
 #[macro_use]
 extern crate ndarray;
 
-use ndarray::{
-    RcArray,
-    Ix,
-};
+use ndarray::prelude::*;
 
 type Ix2 = (Ix, Ix);
 

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use std::cmp;
+use std::ptr as std_ptr;
 use std::slice;
 
 use imp_prelude::*;
@@ -259,6 +260,22 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         arraytraits::debug_bounds_check(self, &index);
         let off = D::stride_offset(&index, &self.strides);
         &mut *self.ptr.offset(off)
+    }
+
+    /// Swap elements at indices `index1` and `index2`.
+    ///
+    /// Indices may be equal.
+    ///
+    /// ***Panics*** if an index is out of bounds.
+    pub fn swap<I>(&mut self, index1: I, index2: I)
+        where S: DataMut,
+              I: NdIndex<Dim=D>,
+    {
+        let ptr1: *mut _ = &mut self[index1];
+        let ptr2: *mut _ = &mut self[index2];
+        unsafe {
+            std_ptr::swap(ptr1, ptr2);
+        }
     }
 
     // `get` for zero-dimensional arrays

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,15 +139,8 @@ mod stacking;
 
 /// Implementation's prelude. Common types used everywhere.
 mod imp_prelude {
+    pub use prelude::*;
     pub use {
-        Axis,
-        ArrayBase,
-        ArrayView,
-        ArrayViewMut,
-        OwnedArray,
-        RcArray,
-        Ix, Ixs,
-        Dimension,
         RemoveAxis,
         Data,
         DataMut,
@@ -160,6 +153,8 @@ mod imp_prelude {
     #[derive(Copy, Clone, Debug)]
     pub struct Priv<T>(pub T);
 }
+
+pub mod prelude;
 
 /// Array index type
 pub type Ix = usize;

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -15,7 +15,6 @@ use numeric_util;
 
 use {
     LinalgScalar,
-    aview0,
 };
 
 /// Numerical methods for arrays.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,44 @@
+// Copyright 2016 bluss and ndarray developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! ndarray prelude.
+//!
+//! This module contains the most used types, type aliases, traits and
+//! functions that you can import easily as a group.
+//!
+//! ```
+//! extern crate ndarray;
+//!
+//! use ndarray::prelude::*;
+//! # fn main() { }
+//! ```
+
+#[doc(no_inline)]
+pub use {
+    ArrayBase,
+    OwnedArray,
+    RcArray,
+    ArrayView,
+    ArrayViewMut,
+};
+#[doc(no_inline)]
+pub use {
+    Axis,
+    Ix, Ixs,
+    Dimension,
+};
+#[doc(no_inline)]
+pub use {
+    NdFloat,
+    AsArray,
+};
+#[doc(no_inline)]
+pub use {
+    arr1, arr2,
+    aview0, aview1, aview2,
+};

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -986,3 +986,18 @@ fn test_all_close() {
     assert!(c.all_close(&aview1(&[1., 2., 3.]), 1.));
     assert!(!c.all_close(&aview1(&[1., 2., 3.]), 0.1));
 }
+
+#[test]
+fn test_swap() {
+    let mut a = arr2(&[[1, 2, 3],
+                       [4, 5, 6],
+                       [7, 8, 9]]);
+    let b = a.clone();
+
+    for i in 0..a.rows() {
+        for j in i + 1..a.cols() {
+            a.swap((i, j), (j, i));
+        }
+    }
+    assert_eq!(a, b.t());
+}

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -1,15 +1,8 @@
 #[macro_use(s)] extern crate ndarray;
 extern crate num as libnum;
 
-use ndarray::RcArray;
+use ndarray::prelude::*;
 use ndarray::{arr0, rcarr1, rcarr2};
-use ndarray::{
-    OwnedArray,
-    Ix, Ixs,
-    AsArray,
-    NdFloat,
-    aview0,
-};
 
 use std::fmt;
 use libnum::Float;


### PR DESCRIPTION
Thanks to @mitaa who enabled #[doc(no_inline)] in rust so that we can have a prelude module without creating a mess! :star2: 

Suggestions for more/less prelude items are welcome.

Fixes #108 