### PR TITLE
expose ArrayView(Mut)::from_ptr, useful for FFI

### DIFF
--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -69,6 +69,19 @@ impl<'a, A, D> ArrayBase<ViewRepr<&'a A>, D>
         ArrayView::new_(ptr, dim, strides)
     }
 
+    /// Create an ArrayView from a raw pointer and shape information
+    ///
+    /// The caller is responsible for ensuring that the pointer is valid
+    /// and coherent with the dim and stride information.
+    pub unsafe fn from_shape_ptr<Sh>(shape: Sh, ptr: *const A) -> Self
+        where Sh: Into<StrideShape<D>>
+    {
+        let shape = shape.into();
+        let dim = shape.dim;
+        let strides = shape.strides;
+        ArrayView::new_(ptr, dim, strides)
+    }
+
     /// Split the array along `axis` and return one view strictly before the
     /// split and one view after the split.
     ///
@@ -165,6 +178,19 @@ impl<'a, A, D> ArrayBase<ViewRepr<&'a mut A>, D>
     ///
     /// This is the recommended way for interfacing with FFI arrays.
     pub unsafe fn from_raw_parts(ptr: *mut A, dim: D, strides: D) -> Self {
+        ArrayViewMut::new_(ptr, dim, strides)
+    }
+
+    /// Create an ArrayViewMut from a raw pointer and shape information
+    ///
+    /// The caller is responsible for ensuring that the pointer is valid
+    /// and coherent with the dim and stride information.
+    pub unsafe fn from_shape_ptr<Sh>(shape: Sh, ptr: *mut A) -> Self
+        where Sh: Into<StrideShape<D>>
+    {
+        let shape = shape.into();
+        let dim = shape.dim;
+        let strides = shape.strides;
         ArrayViewMut::new_(ptr, dim, strides)
     }
 

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -65,7 +65,7 @@ impl<'a, A, D> ArrayBase<ViewRepr<&'a A>, D>
     /// and coherent with the dim and stride information.
     ///
     /// This is the recommended way for interfacing with FFI arrays.
-    pub unsafe fn from_ptr(ptr: *const A, dim: D, strides: D) -> Self {
+    pub unsafe fn from_raw_parts(ptr: *const A, dim: D, strides: D) -> Self {
         ArrayView::new_(ptr, dim, strides)
     }
 
@@ -158,13 +158,13 @@ impl<'a, A, D> ArrayBase<ViewRepr<&'a mut A>, D>
         })
     }
 
-    /// Create an ArrayView from a raw pointer, dim and stride information.
+    /// Create an ArrayViewMut from a raw pointer, shape and stride information.
     ///
     /// The caller is responsible for ensuring that the pointer is valid
     /// and coherent with the dim and stride information.
     ///
     /// This is the recommended way for interfacing with FFI arrays.
-    pub unsafe fn from_ptr(ptr: *mut A, dim: D, strides: D) -> Self {
+    pub unsafe fn from_raw_parts(ptr: *mut A, dim: D, strides: D) -> Self {
         ArrayViewMut::new_(ptr, dim, strides)
     }
 

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -59,6 +59,16 @@ impl<'a, A, D> ArrayBase<ViewRepr<&'a A>, D>
         })
     }
 
+    /// Create an ArrayView from a raw pointer, dim and stride information.
+    ///
+    /// The caller is responsible for ensuring that the pointer is valid
+    /// and coherent with the dim and stride information.
+    ///
+    /// This is the recommended way for interfacing with FFI arrays.
+    pub unsafe fn from_ptr(ptr: *const A, dim: D, strides: D) -> Self {
+        ArrayView::new_(ptr, dim, strides)
+    }
+
     /// Split the array along `axis` and return one view strictly before the
     /// split and one view after the split.
     ///
@@ -146,6 +156,16 @@ impl<'a, A, D> ArrayBase<ViewRepr<&'a mut A>, D>
                 Self::new_(xs.as_mut_ptr(), dim, strides)
             }
         })
+    }
+
+    /// Create an ArrayView from a raw pointer, dim and stride information.
+    ///
+    /// The caller is responsible for ensuring that the pointer is valid
+    /// and coherent with the dim and stride information.
+    ///
+    /// This is the recommended way for interfacing with FFI arrays.
+    pub unsafe fn from_ptr(ptr: *mut A, dim: D, strides: D) -> Self {
+        ArrayViewMut::new_(ptr, dim, strides)
     }
 
     /// Split the array along `axis` and return one mutable view strictly

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1038,15 +1038,15 @@ fn test_shape() {
 }
 
 #[test]
-fn test_view_from_ptr() {
+fn test_view_from_raw_parts() {
     let data = [0, 1, 2, 3, 4, 5];
     let ptr = &data[0] as *const i32;
-    let view = unsafe { ArrayView::from_ptr(ptr, (2, 3), (3, 1)) };
+    let view = unsafe { ArrayView::from_raw_parts(ptr, (2, 3), (3, 1)) };
     assert_eq!(view[[1, 2]], 5);
 
     let mut data = data;
     let ptr = &mut data[0] as *mut i32;
-    let mut view = unsafe { ArrayViewMut::from_ptr(ptr, (2, 3), (3, 1)) };
+    let mut view = unsafe { ArrayViewMut::from_raw_parts(ptr, (2, 3), (3, 1)) };
     view[[1, 2]] = 6;
     assert_eq!(view[[1, 2]], 6);
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1036,3 +1036,17 @@ fn test_shape() {
     assert_eq!(b.strides(), &[1, 1, 2]);
     assert_eq!(c.strides(), &[1, 3, 1]);
 }
+
+#[test]
+fn test_view_from_ptr() {
+    let data = [0, 1, 2, 3, 4, 5];
+    let ptr = &data[0] as *const i32;
+    let view = unsafe { ArrayView::from_ptr(ptr, (2, 3), (3, 1)) };
+    assert_eq!(view[[1, 2]], 5);
+
+    let mut data = data;
+    let ptr = &mut data[0] as *mut i32;
+    let mut view = unsafe { ArrayViewMut::from_ptr(ptr, (2, 3), (3, 1)) };
+    view[[1, 2]] = 6;
+    assert_eq!(view[[1, 2]], 6);
+}

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1043,10 +1043,15 @@ fn test_view_from_raw_parts() {
     let ptr = &data[0] as *const i32;
     let view = unsafe { ArrayView::from_raw_parts(ptr, (2, 3), (3, 1)) };
     assert_eq!(view[[1, 2]], 5);
+    let view = unsafe { ArrayView::from_shape_ptr((2, 3), ptr) };
+    assert_eq!(view[[0, 1]], 1);
 
     let mut data = data;
     let ptr = &mut data[0] as *mut i32;
     let mut view = unsafe { ArrayViewMut::from_raw_parts(ptr, (2, 3), (3, 1)) };
     view[[1, 2]] = 6;
     assert_eq!(view[[1, 2]], 6);
+    let mut view = unsafe { ArrayViewMut::from_shape_ptr((2, 3), ptr) };
+    view[[0, 1]] = 0;
+    assert_eq!(view[[0, 1]], 0);
 }


### PR DESCRIPTION
See #209 for the intent: fast-path for interfacing with FFI-allocated arrays.