### PR TITLE
num-traits and -complex to 0.1.35 to support serde 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ bench = false
 test = false
 
 [dependencies.num-traits]
-version = "0.1.32"
+version = "0.1.35"
 default-features = false
 
 [dependencies.num-complex]
-version = "0.1.32"
+version = "0.1.35"
 default-features = false
 
 [dependencies.itertools]


### PR DESCRIPTION
Upgraded `num-traits` and `num-complex` to `0.1.35` so that all of (?) `ndarray` supports `serde 0.8`.