### PR TITLE
impl ExactSizeIterator for Indexed, IndexedMut

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -279,6 +279,10 @@ impl<'a, A, D: Dimension> Iterator for Indexed<'a, A, D> {
     }
 }
 
+impl<'a, A, D> ExactSizeIterator for Indexed<'a, A, D>
+    where D: Dimension
+{}
+
 impl<'a, A, D: Dimension> Iterator for ElementsMut<'a, A, D> {
     type Item = &'a mut A;
     #[inline]
@@ -355,6 +359,10 @@ impl<'a, A, D: Dimension> Iterator for IndexedMut<'a, A, D> {
         (len, Some(len))
     }
 }
+
+impl<'a, A, D> ExactSizeIterator for IndexedMut<'a, A, D>
+    where D: Dimension
+{}
 
 /// An iterator that traverses over all dimensions but the innermost,
 /// and yields each inner row.


### PR DESCRIPTION
Resolves #226 

Hope it's fine that my editor removed the trailing whitespace in that unrelated line :D
You're lucky I don't have automatic rustfmt enabled! I'd recommend installing rustfmt yourself and running `cargo fmt` to prevent future PR diffs from exploding due to automatic formatting... Apart from the obvious benefit of consistent formatting ;)