### PR TITLE
Backport 'impl ExactSizeIterator for Indexed, IndexedMut'

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -278,6 +278,10 @@ impl<'a, A, D: Dimension> Iterator for Indexed<'a, A, D> {
     }
 }
 
+impl<'a, A, D> ExactSizeIterator for Indexed<'a, A, D>
+    where D: Dimension
+{}
+
 impl<'a, A, D: Dimension> Iterator for ElementsMut<'a, A, D> {
     type Item = &'a mut A;
     #[inline]
@@ -354,6 +358,10 @@ impl<'a, A, D: Dimension> Iterator for IndexedMut<'a, A, D> {
         (len, Some(len))
     }
 }
+
+impl<'a, A, D> ExactSizeIterator for IndexedMut<'a, A, D>
+    where D: Dimension
+{}
 
 /// An iterator that traverses over all dimensions but the innermost,
 /// and yields each inner row.


### PR DESCRIPTION
I'll still try out the master version and report back in case of problems, but I think this is useful to have backported either way.