### PR TITLE
Rename raw_dimension → raw_dim, better docs, expand prelude

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Recent Changes (ndarray)
   - Constructors and methods that take tuples for array sizes, like ``Array::zeros,``
     ``Array::from_shape_vec``, ``.into_shape()`` and so on will continue to work
     with tuples.
-  - The array method ``.raw_dimension()`` returns the shape description
+  - The array method ``.raw_dim()`` returns the shape description
     ``D`` as it is.
   - Renamed iterators for consistency (each iterator is named for the
     method that creates it, for example ``.iter()`` returns ``Iter``).

--- a/benches/higher-order.rs
+++ b/benches/higher-order.rs
@@ -7,7 +7,6 @@ use test::Bencher;
 #[macro_use(s)]
 extern crate ndarray;
 use ndarray::prelude::*;
-use ndarray::ArrayViewMut2;
 
 const N: usize = 1024;
 const X: usize = 64;

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -6,7 +6,6 @@ use test::Bencher;
 #[macro_use(s)]
 extern crate ndarray;
 use ndarray::prelude::*;
-use ndarray::Array2;
 
 #[bench]
 fn iter_sum_2d_regular(bench: &mut Bencher)

--- a/examples/convo.rs
+++ b/examples/convo.rs
@@ -6,7 +6,6 @@ extern crate num_traits;
 use num_traits::Float;
 
 use ndarray::prelude::*;
-use ndarray::{ArrayView2, ArrayViewMut2};
 
 const SOBEL_X: [[f32; 3]; 3] = [[-1., 0., 1.], [-2., 0., 2.], [-1., 0., 1.]];
 const SOBEL_Y: [[f32; 3]; 3] = [[ 1., 2., 1.], [ 0., 0., 0.], [-1., -2., -1.]];

--- a/examples/life.rs
+++ b/examples/life.rs
@@ -2,7 +2,6 @@
 extern crate ndarray;
 
 use ndarray::prelude::*;
-use ndarray::Array2;
 
 const INPUT: &'static [u8] = include_bytes!("life.txt");
 //const INPUT: &'static [u8] = include_bytes!("lifelite.txt");

--- a/src/array_serde.rs
+++ b/src/array_serde.rs
@@ -50,7 +50,7 @@ impl<A, D, S> Serialize for ArrayBase<S, D>
     {
         let mut struct_state = try!(serializer.serialize_struct("Array", 3));
         try!(serializer.serialize_struct_elt(&mut struct_state, "v", ARRAY_FORMAT_VERSION));
-        try!(serializer.serialize_struct_elt(&mut struct_state, "dim", self.raw_dimension()));
+        try!(serializer.serialize_struct_elt(&mut struct_state, "dim", self.raw_dim()));
         try!(serializer.serialize_struct_elt(&mut struct_state, "data", Sequence(self.iter())));
         serializer.serialize_struct_end(struct_state)
     }

--- a/src/array_serde.rs
+++ b/src/array_serde.rs
@@ -13,7 +13,6 @@ use imp_prelude::*;
 
 use super::arraytraits::ARRAY_FORMAT_VERSION;
 use super::Iter;
-use Dim;
 use dimension::DimPrivate;
 
 /// **Requires crate feature `"serde"`**

--- a/src/array_serialize.rs
+++ b/src/array_serialize.rs
@@ -11,7 +11,6 @@ use super::arraytraits::ARRAY_FORMAT_VERSION;
 
 use imp_prelude::*;
 
-use Dim;
 use dimension::DimPrivate;
 
 /// **Requires crate feature `"rustc-serialize"`**

--- a/src/dimension/dim.rs
+++ b/src/dimension/dim.rs
@@ -34,7 +34,7 @@ use Ix;
 ///
 /// let mut array = Array2::zeros((3, 2));
 /// array[[0, 0]] = 1.;
-/// assert_eq!(array.raw_dimension(), Dim([3, 2]));
+/// assert_eq!(array.raw_dim(), Dim([3, 2]));
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub struct Dim<I: ?Sized> {

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -13,7 +13,7 @@ use std::ops::{Add, Sub, Mul, AddAssign, SubAssign, MulAssign};
 
 use itertools::{enumerate, zip};
 
-use {Ix, Ixs, Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn, Dim, Si};
+use {Ix, Ixs, Ix0, Ix1, Ix2, Ix3, IxDyn, Dim, Si};
 use IntoDimension;
 use {ArrayView1, ArrayViewMut1};
 use {zipsl, zipsl_mut, ZipExt};

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -315,7 +315,7 @@ fn abs_index(len: Ixs, index: Ixs) -> Ix {
 // Dimension impls
 
 
-unsafe impl Dimension for Ix0 {
+unsafe impl Dimension for Dim<[Ix; 0]> {
     type SliceArg = [Si; 0];
     type Pattern = ();
     // empty product is 1 -> size is 1
@@ -336,7 +336,7 @@ unsafe impl Dimension for Ix0 {
 }
 
 
-unsafe impl Dimension for Ix1 {
+unsafe impl Dimension for Dim<[Ix; 1]> {
     type SliceArg = [Si; 1];
     type Pattern = Ix;
     #[inline]
@@ -405,7 +405,7 @@ unsafe impl Dimension for Ix1 {
     }
 }
 
-unsafe impl Dimension for Ix2 {
+unsafe impl Dimension for Dim<[Ix; 2]> {
     type SliceArg = [Si; 2];
     type Pattern = (Ix, Ix);
     #[inline]
@@ -539,7 +539,7 @@ unsafe impl Dimension for Ix2 {
     }
 }
 
-unsafe impl Dimension for Ix3 {
+unsafe impl Dimension for Dim<[Ix; 3]> {
     type SliceArg = [Si; 3];
     type Pattern = (Ix, Ix, Ix);
     #[inline]
@@ -621,7 +621,7 @@ unsafe impl Dimension for Ix3 {
 
 macro_rules! large_dim {
     ($n:expr, $name:ident, $($ix:ident),+) => (
-        unsafe impl Dimension for $name {
+        unsafe impl Dimension for Dim<[Ix; $n]> {
             type SliceArg = [Si; $n];
             type Pattern = ($($ix,)*);
             #[inline]

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,7 @@ impl ShapeError {
 #[derive(Copy, Clone, Debug)]
 pub enum ErrorKind {
     /// incompatible shape
-    IncompatibleShape,
+    IncompatibleShape = 1,
     /// incompatible memory layout
     IncompatibleLayout,
     /// the shape does not fit inside type limits

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -166,12 +166,18 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
 
     /// Return an iterator of indexes and references to the elements of the array.
     ///
+    /// Elements are visited in the *logical order* of the array, which
+    /// is where the rightmost index is varying the fastest.
+    ///
     /// Iterator element type is `(D::Pattern, &A)`.
     pub fn indexed_iter(&self) -> IndexedIter<A, D> {
         IndexedIter(self.view().into_elements_base())
     }
 
     /// Return an iterator of indexes and mutable references to the elements of the array.
+    ///
+    /// Elements are visited in the *logical order* of the array, which
+    /// is where the rightmost index is varying the fastest.
     ///
     /// Iterator element type is `(D::Pattern, &mut A)`.
     pub fn indexed_iter_mut(&mut self) -> IndexedIterMut<A, D>

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -195,7 +195,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
-    /// (**Panics** if `D` is `Vec` and `indexes` does not match the number of array axes.)
+    /// (**Panics** if `D` is `IxDyn` and `indexes` does not match the number of array axes.)
     pub fn slice(&self, indexes: &D::SliceArg) -> ArrayView<A, D> {
         let mut arr = self.view();
         arr.islice(indexes);
@@ -209,7 +209,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
-    /// (**Panics** if `D` is `Vec` and `indexes` does not match the number of array axes.)
+    /// (**Panics** if `D` is `IxDyn` and `indexes` does not match the number of array axes.)
     pub fn slice_mut(&mut self, indexes: &D::SliceArg) -> ArrayViewMut<A, D>
         where S: DataMut
     {
@@ -225,7 +225,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
-    /// (**Panics** if `D` is `Vec` and `indexes` does not match the number of array axes.)
+    /// (**Panics** if `D` is `IxDyn` and `indexes` does not match the number of array axes.)
     pub fn islice(&mut self, indexes: &D::SliceArg) {
         let offset = D::do_slices(&mut self.dim, &mut self.strides, indexes);
         unsafe {

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -82,7 +82,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     }
 
     /// Return the shape of the array as it stored in the array.
-    pub fn raw_dimension(&self) -> D {
+    pub fn raw_dim(&self) -> D {
         self.dim.clone()
     }
 
@@ -457,7 +457,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
             sub.isubview(axis, i);
         }
         if subs.is_empty() {
-            let mut dim = self.raw_dimension();
+            let mut dim = self.raw_dim();
             dim.set_axis(axis, 0);
             unsafe {
                 Array::from_shape_vec_unchecked(dim, vec![])
@@ -1124,7 +1124,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         } else if self.dim.ndim() == rhs.dim.ndim() && self.shape() == rhs.shape() {
             self.zip_mut_with_same_shape(rhs, f);
         } else {
-            let rhs_broadcast = rhs.broadcast_unwrap(self.raw_dimension());
+            let rhs_broadcast = rhs.broadcast_unwrap(self.raw_dim());
             self.zip_mut_with_by_rows(&rhs_broadcast, f);
         }
     }
@@ -1285,7 +1285,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
               F: FnMut(&B, &A) -> B,
               B: Clone,
     {
-        let mut res = Array::from_elem(self.raw_dimension().remove_axis(axis), init);
+        let mut res = Array::from_elem(self.raw_dim().remove_axis(axis), init);
         for subview in self.axis_iter(axis) {
             res.zip_mut_with(&subview, |x, y| *x = fold(x, y));
         }

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -358,11 +358,11 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// ```
     /// use ndarray::{arr2, ArrayView, Axis};
     ///
-    /// let a = arr2(&[[1., 2.],    // -- axis 0, row 0
-    ///                [3., 4.],    // -- axis 0, row 1
-    ///                [5., 6.]]);  // -- axis 0, row 2
-    /// //               \   \
-    /// //                \   axis 1, column 1
+    /// let a = arr2(&[[1., 2. ],    // ... axis 0, row 0
+    ///                [3., 4. ],    // --- axis 0, row 1
+    ///                [5., 6. ]]);  // ... axis 0, row 2
+    /// //               .   \
+    /// //                .   axis 1, column 1
     /// //                 axis 1, column 0
     /// assert!(
     ///     a.subview(Axis(0), 1) == ArrayView::from(&[3., 4.]) &&
@@ -384,8 +384,11 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// ```
     /// use ndarray::{arr2, aview2, Axis};
     ///
-    /// let mut a = arr2(&[[1., 2.],
-    ///                    [3., 4.]]);
+    /// let mut a = arr2(&[[1., 2. ],
+    ///                    [3., 4. ]]);
+    /// //                   .   \
+    /// //                    .   axis 1, column 1
+    /// //                     axis 1, column 0
     ///
     /// {
     ///     let mut column1 = a.subview_mut(Axis(1), 1);

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -55,11 +55,21 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         self.dim[axis.axis()]
     }
 
+    /// Return the number of dimensions (axes) in the array
+    pub fn ndim(&self) -> usize {
+        self.dim.ndim()
+    }
+
     /// Return the shape of the array in its “pattern” form,
     /// an integer in the one-dimensional case, tuple in the n-dimensional cases
     /// and so on.
     pub fn dim(&self) -> D::Pattern {
         self.dim.clone().into_pattern()
+    }
+
+    /// Return the shape of the array as it stored in the array.
+    pub fn raw_dim(&self) -> D {
+        self.dim.clone()
     }
 
     /// Return the shape of the array as a slice.
@@ -74,16 +84,6 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         unsafe {
             slice::from_raw_parts(s.as_ptr() as *const _, s.len())
         }
-    }
-
-    /// Return the number of dimensions (axes) in the array
-    pub fn ndim(&self) -> usize {
-        self.dim.ndim()
-    }
-
-    /// Return the shape of the array as it stored in the array.
-    pub fn raw_dim(&self) -> D {
-        self.dim.clone()
     }
 
     /// Return a read-only view of the array

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,6 @@ mod stacking;
 /// Implementation's prelude. Common types used everywhere.
 mod imp_prelude {
     pub use prelude::*;
-    pub use aliases::*;
     pub use {
         RemoveAxis,
         Data,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,44 +11,40 @@
 //! The `ndarray` crate provides an N-dimensional container for general elements
 //! and for numerics.
 //!
-//! - [`ArrayBase`](struct.ArrayBase.html):
-//!   The N-dimensional array type itself.
-//! - [`Array`](type.Array.html):
-//!   An array where the data is owned uniquely.
-//! - [`RcArray`](type.RcArray.html):
-//!   An array where the data has shared ownership and is copy on write.
-//! - [`ArrayView`](type.ArrayView.html), [`ArrayViewMut`](type.ArrayViewMut.html):
-//!   Lightweight array views.
+//! - [**`ArrayBase`**](struct.ArrayBase.html):
+//!   The N-dimensional array type itself.<br>
+//!   It is used to implement both the owned arrays and the views; see its docs
+//!   for an overview of all array features.  
+//! - The main specific array type is [**`Array`**](type.Array.html), which owns
+//! its elements.
 //!
 //! ## Highlights
 //!
 //! - Generic N-dimensional array
 //! - Slicing, also with arbitrary step size, and negative indices to mean
 //!   elements from the end of the axis.
-//! - There is both a copy on write array (`RcArray`), or a regular uniquely owned array
-//!   (`Array`), and both can use read-only and read-write array views.
-//! - Iteration and most operations are efficient on arrays with contiguous
-//!   innermost dimension.
+//! - Views and subviews of arrays; iterators that yield subviews.
+//! - Higher order operations and arithmetic are performant
 //! - Array views can be used to slice and mutate any `[T]` data using
 //!   `ArrayView::from` and `ArrayViewMut::from`.
 //!
 //! ## Crate Status
 //!
-//! - Still iterating on and evolving the API
+//! - Still iterating on and evolving the crate
 //!   + The crate is continuously developing, and breaking changes are expected
-//!     during evolution from version to version. We adhere to semver,
-//!     but alpha releases break at will.
-//!   + We adopt the newest stable rust features we need.
-//! - Performance status:
-//!   + Performance of an operation depends on the memory layout of the array
-//!     or array view. Especially if it's a binary operation, which
-//!     needs matching memory layout to be efficient (with some exceptions).
-//!   + Arithmetic optimizes very well if the arrays are have contiguous inner dimension.
+//!     during evolution from version to version. We adopt the newest stable
+//!     rust features if we need them.
+//! - Performance:
+//!   + Prefer higher order methods and arithmetic operations on arrays first,
+//!     then iteration, and as a last priority using indexed algorithms.
 //!   + The higher order functions like ``.map()``, ``.map_inplace()`` and
 //!     ``.zip_mut_with()`` are the most efficient ways to
 //!     perform single traversal and lock step traversal respectively.
-//!   + ``.iter()`` is efficient for c-contiguous arrays.
-//!   + Can use BLAS in matrix multiplication.
+//!   + Performance of an operation depends on the memory layout of the array
+//!     or array view. Especially if it's a binary operation, which
+//!     needs matching memory layout to be efficient (with some exceptions).
+//!   + Efficient floating point matrix multiplication even for very large
+//!     matrices; can optionally use BLAS to improve it further.
 //!
 //! ## Crate Feature Flags
 //!
@@ -480,11 +476,27 @@ pub struct ArrayBase<S, D>
     strides: D,
 }
 
-/// Array where the data is reference counted and copy on write, it
-/// can act as both an owner as the data as well as a lightweight view.
+/// An array where the data has shared ownership and is copy on write.
+/// It can act as both an owner as the data as well as a shared reference (view
+/// like).
 pub type RcArray<A, D> = ArrayBase<Rc<Vec<A>>, D>;
 
-/// Array where the data is owned uniquely.
+/// An array that owns its data uniquely.
+///
+/// `Array` is the main n-dimensional array type, and it owns all its array
+/// elements.
+///
+/// [**`ArrayBase`**](struct.ArrayBase.html) is used to implement both the owned
+/// arrays and the views; see its docs for an overview of all array features.  
+///
+/// See also:
+///
+/// + [Constructor Methods for Owned Arrays](struct.ArrayBase.html#constructor-methods-for-owned-arrays)
+/// + [Methods For All Array Types](struct.ArrayBase.html#methods-for-all-array-types)
+/// + Dimensionality-specific type alises
+/// [`Array1`](Array1.t.html),
+/// [`Array2`](Array2.t.html),
+/// [`Array3`](Array3.t.html) and so on.
 pub type Array<A, D> = ArrayBase<Vec<A>, D>;
 
 #[deprecated(note="Use the type alias `Array` instead")]

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -358,8 +358,8 @@ fn mat_mul_impl<A>(alpha: A,
                         }
                     };
                     let n = match rhs_trans {
-                        CblasNoTrans => rhs_.raw_dimension()[1],
-                        _ => rhs_.raw_dimension()[0],
+                        CblasNoTrans => rhs_.raw_dim()[1],
+                        _ => rhs_.raw_dim()[0],
                     };
                     // adjust strides, these may [1, 1] for column matrices
                     let lhs_stride = cmp::max(lhs_.strides()[0] as blas_index, k as blas_index);

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -124,7 +124,7 @@ impl<A, S, D> ArrayBase<S, D>
               S2: Data<Elem=A>,
               E: Dimension,
     {
-        let rhs_broadcast = rhs.broadcast_unwrap(self.raw_dimension());
+        let rhs_broadcast = rhs.broadcast_unwrap(self.raw_dim());
         self.iter().zip(rhs_broadcast.iter()).all(|(x, y)| (*x - *y).abs() <= tol)
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -28,27 +28,41 @@ pub use {
 };
 
 #[doc(no_inline)]
-#[allow(deprecated)]
-pub use OwnedArray;
-
-#[doc(no_inline)]
 pub use {
     Axis,
+    Dim,
     Ix, Ixs,
     Dimension,
 };
+
+#[doc(no_inline)]
+pub use {Array0, Array1, Array2, Array3, Array4, Array5, Array6, ArrayD};
+
+#[doc(no_inline)]
+pub use {ArrayView0, ArrayView1, ArrayView2, ArrayView3, ArrayView4, ArrayView5,
+ArrayView6, ArrayViewD};
+
+#[doc(no_inline)]
+pub use {ArrayViewMut0, ArrayViewMut1, ArrayViewMut2, ArrayViewMut3,
+ArrayViewMut4, ArrayViewMut5, ArrayViewMut6, ArrayViewMutD};
+
+#[doc(no_inline)]
+pub use {Ix0, Ix1, Ix2, Ix3, Ix4, Ix5, Ix6, IxDyn};
+
 #[doc(no_inline)]
 pub use {
-    NdFloat,
-    AsArray,
-};
-#[doc(no_inline)]
-pub use {
-    arr1, arr2,
+    arr0, arr1, arr2,
     aview0, aview1, aview2,
+    aview_mut1,
 };
 
 #[doc(no_inline)]
 pub use {
     ShapeBuilder,
+};
+
+#[doc(no_inline)]
+pub use {
+    NdFloat,
+    AsArray,
 };

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -37,12 +37,12 @@ pub fn stack<'a, A, D>(axis: Axis, arrays: &[ArrayView<'a, A, D>])
     if arrays.len() == 0 {
         return Err(from_kind(ErrorKind::Unsupported));
     }
-    let mut res_dim = arrays[0].raw_dimension();
+    let mut res_dim = arrays[0].raw_dim();
     if axis.axis() >= res_dim.ndim() {
         return Err(from_kind(ErrorKind::OutOfBounds));
     }
     let common_dim = res_dim.remove_axis(axis);
-    if arrays.iter().any(|a| a.raw_dimension().remove_axis(axis) != common_dim) {
+    if arrays.iter().any(|a| a.raw_dim().remove_axis(axis) != common_dim) {
         return Err(from_kind(ErrorKind::IncompatibleShape));
     }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -7,11 +7,8 @@ extern crate itertools;
 use ndarray::{S, Si};
 use ndarray::prelude::*;
 use ndarray::{
-    Array1,
     rcarr2,
-    arr0, arr3,
-    aview_mut1,
-    Ix0, Ix2,
+    arr3,
 };
 use ndarray::indices;
 use itertools::free::enumerate;

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -515,7 +515,7 @@ fn from_vec_dim_stride_2d_3() {
     let a = arr3(&[[[1]],
                    [[2]],
                    [[3]]]);
-    let d = a.raw_dimension();
+    let d = a.raw_dim();
     let s = d.default_strides();
     assert_matches!(Array::from_shape_vec(d.strides(s), a.as_slice().unwrap().to_vec()), Ok(_));
 }
@@ -525,7 +525,7 @@ fn from_vec_dim_stride_2d_4() {
     let a = arr3(&[[[1]],
                    [[2]],
                    [[3]]]);
-    let d = a.raw_dimension();
+    let d = a.raw_dim();
     let s = d.fortran_strides();
     assert_matches!(Array::from_shape_vec(d.strides(s), a.as_slice().unwrap().to_vec()), Ok(_));
 }
@@ -533,7 +533,7 @@ fn from_vec_dim_stride_2d_4() {
 #[test]
 fn from_vec_dim_stride_2d_5() {
     let a = arr3(&[[[1, 2, 3]]]);
-    let d = a.raw_dimension();
+    let d = a.raw_dim();
     let s = d.fortran_strides();
     assert_matches!(Array::from_shape_vec(d.strides(s), a.as_slice().unwrap().to_vec()), Ok(_));
 }

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -2,7 +2,6 @@
 extern crate ndarray;
 
 use ndarray::prelude::*;
-use ndarray::Dim;
 
 #[test]
 fn broadcast_1()

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -2,11 +2,9 @@
 extern crate num_traits;
 
 use ndarray::prelude::*;
-use ndarray::{arr0, rcarr1, rcarr2};
+use ndarray::{rcarr1, rcarr2};
 use ndarray::{LinalgScalar, Data};
 use ndarray::linalg::general_mat_mul;
-use ndarray::Array2;
-use ndarray::Ix2;
 
 use std::fmt;
 use num_traits::Float;


### PR DESCRIPTION
- The prelude gains all the dimensionality-specific type aliases.