### PR TITLE
Fix two bugs in Array::clone

### DIFF
--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -8,7 +8,7 @@
 
 //! The data (inner representation) traits for ndarray
 
-use std::mem;
+use std::mem::{self, size_of};
 use std::rc::Rc;
 
 use {
@@ -124,9 +124,12 @@ unsafe impl<A> DataClone for Vec<A>
 {
     unsafe fn clone_with_ptr(&self, ptr: *mut Self::Elem) -> (Self, *mut Self::Elem) {
         let mut u = self.clone();
-        let our_off = (self.as_ptr() as isize - ptr as isize) /
-                      mem::size_of::<A>() as isize;
-        let new_ptr = u.as_mut_ptr().offset(our_off);
+        let mut new_ptr = u.as_mut_ptr();
+        if size_of::<A>() != 0 {
+            let our_off = (self.as_ptr() as isize - ptr as isize) /
+                          mem::size_of::<A>() as isize;
+            new_ptr = new_ptr.offset(our_off);
+        }
         (u, new_ptr)
     }
 }

--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -126,7 +126,7 @@ unsafe impl<A> DataClone for Vec<A>
         let mut u = self.clone();
         let mut new_ptr = u.as_mut_ptr();
         if size_of::<A>() != 0 {
-            let our_off = (self.as_ptr() as isize - ptr as isize) /
+            let our_off = (ptr as isize - self.as_ptr() as isize) /
                           mem::size_of::<A>() as isize;
             new_ptr = new_ptr.offset(our_off);
         }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1086,3 +1086,20 @@ fn test_map_axis() {
     let answer2 = arr1(&[6, 15, 24, 33]);
     assert_eq!(c, answer2);
 }
+
+#[test]
+fn test_array_clone_unalias() {
+    let a = Array2::<i32>::zeros((3, 3));
+    let mut b = a.clone();
+    b.fill(1);
+    assert!(a != b);
+    assert_eq!(a, Array2::zeros((3, 3)));
+}
+
+#[test]
+fn test_array_clone_same_view() {
+    let mut a = Array::from_iter(0..9).into_shape((3, 3)).unwrap();
+    a.islice(s![..;-1, ..;-1]);
+    let b = a.clone();
+    assert_eq!(a, b);
+}

--- a/tests/zst.rs
+++ b/tests/zst.rs
@@ -1,0 +1,18 @@
+
+extern crate ndarray;
+
+use ndarray::arr2;
+
+#[test]
+fn test_swap() {
+    let mut a = arr2(&[[();3];3]);
+
+    let b = a.clone();
+
+    for i in 0..a.rows() {
+        for j in i + 1..a.cols() {
+            a.swap((i, j), (j, i));
+        }
+    }
+    assert_eq!(a, b.t());
+}


### PR DESCRIPTION
You'd think that a simple function would not have bugs.

1. Did not handle the ZST case at all. See issue #234, this bug was found by @floatn
2. Did not move the pointer's relative offset correctly (applies when the array had a view of its data storage that puts the first element away from the first element of the storage). This is a more serious bug, IMO.