### PR TITLE
ndarray::Array macro array![]

### DIFF
--- a/src/free_functions.rs
+++ b/src/free_functions.rs
@@ -11,6 +11,38 @@ use std::mem::{size_of, forget};
 
 use imp_prelude::*;
 
+/// Easily create an [**`Array`**](type.Array.html) of up to 3 dimensions.
+/// 
+/// ```
+/// #[macro_use(array)]
+/// extern crate ndarray;
+///
+/// fn main() {
+///     let a1 = array![1, 2, 3, 4];
+///
+///     let a2 = array![[1, 2], [3, 4]];
+/// 
+///     let a3 = array![[[1, 2], [3, 4]], 
+///                     [[5, 6], [7, 8]]];
+///
+///     assert_eq!(a1.shape(), &[4]);
+///     assert_eq!(a2.shape(), &[2, 2]);
+///     assert_eq!(a3.shape(), &[2, 2, 2]);
+/// }
+/// ```
+#[macro_export]
+macro_rules! array {
+    ($([$([$($x:expr),*]),*]),*) => {{
+        $crate::Array3::from(vec![$([$([$($x,)*],)*],)*])
+    }};
+    ($([$($x:expr),*]),*) => {{
+        $crate::Array2::from(vec![$([$($x,)*],)*])
+    }};
+    ($($x:expr),*) => {{
+        $crate::Array::from_vec(vec![$($x,)*])
+    }};
+}
+
 /// Create a zero-dimensional array with the element `x`.
 pub fn arr0<A>(x: A) -> Array0<A>
 {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1126,3 +1126,14 @@ fn test_array_clone_same_view() {
     let b = a.clone();
     assert_eq!(a, b);
 }
+
+#[test]
+fn array_macros() {
+    // array
+    let a1 = array![1, 2, 3];
+    assert_eq!(a1, arr1(&[1, 2, 3]));
+    let a2 = array![[1, 2], [3, 4], [5, 6]];
+    assert_eq!(a2, arr2(&[[1, 2], [3, 4], [5, 6]]));
+    let a3 = array![[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
+    assert_eq!(a3, arr3(&[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]));
+}


### PR DESCRIPTION
This allows for Array and RcArray creation without specifying the dimensionality using macros.
On a sidenote, this also allows for compile time flattening of arrays, I've implemented a version of this [here](https://play.rust-lang.org/?gist=4317bd5029ff890669341b16861e5b0e&version=nightly&backtrace=0), I don't know if doing something similar to this is more efficient then what is being done now in rust-ndarray but maybe you find it interesting.