### PR TITLE
Add .to_vec() for one dimensional arrays

### DIFF
--- a/src/impl_1d.rs
+++ b/src/impl_1d.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 bluss and ndarray developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+//! Methods for one-dimensional arrays.
+use imp_prelude::*;
+
+impl<A, S> ArrayBase<S, Ix1>
+    where S: Data<Elem=A>,
+{
+    /// Return an vector with the elements of the one-dimensional array.
+    pub fn to_vec(&self) -> Vec<A>
+        where A: Clone,
+    {
+        if let Some(slc) = self.as_slice() {
+            slc.to_vec()
+        } else {
+            ::iterators::to_vec(self.iter().map(|x| x.clone()))
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,6 +601,7 @@ impl<A, S, D> ArrayBase<S, D>
 }
 
 
+mod impl_1d;
 mod impl_2d;
 
 mod numeric;

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1097,6 +1097,20 @@ fn test_map_axis() {
 }
 
 #[test]
+fn test_to_vec() {
+    let mut a = arr2(&[[1, 2, 3],
+                       [4, 5, 6],
+                       [7, 8, 9],
+                       [10,11,12]]);
+
+    a.islice(s![..;-1, ..]);
+    assert_eq!(a.row(3).to_vec(), vec![1, 2, 3]);
+    assert_eq!(a.column(2).to_vec(), vec![12, 9, 6, 3]);
+    a.islice(s![.., ..;-1]);
+    assert_eq!(a.row(3).to_vec(), vec![3, 2, 1]);
+}
+
+#[test]
 fn test_array_clone_unalias() {
     let a = Array::<i32, _>::zeros((3, 3));
     let mut b = a.clone();


### PR DESCRIPTION
Fixes #258 