### PR TITLE
ndarray-parallel crate: Rayon + ndarray integration, as a crate in the land between

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,5 @@ script:
       cargo test --release --verbose --features "" &&
       CARGO_TARGET_DIR=target/ cargo test --manifest-path=serialization-tests/Cargo.toml --verbose &&
       CARGO_TARGET_DIR=target/ cargo test --manifest-path=numeric-tests/Cargo.toml --verbose &&
+      CARGO_TARGET_DIR=target/ cargo test --manifest-path=parallel/Cargo.toml --verbose &&
       ([ "$BENCH" != 1 ] || cargo bench --no-run --verbose --features "$FEATURES")

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ndarray-parallel"
+version = "0.1.0"
+authors = ["bluss"]
+
+[dependencies]
+rayon = "0.6"
+ndarray = { version = "0.7.2", path = "../" }

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -6,3 +6,7 @@ authors = ["bluss"]
 [dependencies]
 rayon = "0.6"
 ndarray = { version = "0.7.2", path = "../" }
+
+[dev-dependencies]
+num_cpus = "1.2"
+

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -2,6 +2,14 @@
 name = "ndarray-parallel"
 version = "0.1.0"
 authors = ["bluss"]
+license = "MIT/Apache-2.0"
+
+repository = "https://github.com/bluss/rust-ndarray"
+documentation = "https://docs.rs/ndarray-parallel/"
+
+description = "Parallelization for ndarray (using rayon)."
+
+keywords = ["data-structure", "multidimensional", "parallel", "concurrent"]
 
 [dependencies]
 rayon = "0.6"

--- a/parallel/README.rst
+++ b/parallel/README.rst
@@ -19,7 +19,8 @@ __ http://docs.rs/ndarray-parallel/
 Highlights
 ----------
 
-- Parallel elementwise (no order) and axis iterators
+- Parallel elementwise (no order) iterator
+- Parallel `.axis_iter()` (and `_mut`)
 
 Status and Lookout
 ------------------
@@ -27,9 +28,9 @@ Status and Lookout
 - Still iterating on and evolving the crate
 
   + A separate crate is less convenient (doesn't use rayon IntoParallelIterator
-    trait, but a separate crate) but allows rapid iteration and we can follow
+    trait, but a separate trait) but allows rapid iteration and we can follow
     the evolution of rayon's internals.
-  + This crate is double pace: For every ndarray or rayon major version, this
+    This crate is double pace: For every ndarray or rayon major version, this
     crate goes up one major version.
 
 - Performance:

--- a/parallel/README.rst
+++ b/parallel/README.rst
@@ -1,0 +1,64 @@
+ndarray-parallel
+================
+
+``ndarray-parallel`` integrates ndarray with rayon__ for simple parallelization.
+
+__ https://github.com/nikomatsakis/rayon
+Please read the `API documentation here`__
+
+__ http://docs.rs/ndarray-parallel/
+
+|build_status|_ |crates|_
+
+.. |build_status| image:: https://travis-ci.org/bluss/rust-ndarray.svg?branch=master
+.. _build_status: https://travis-ci.org/bluss/rust-ndarray
+
+.. |crates| image:: http://meritbadge.herokuapp.com/ndarray-parallel
+.. _crates: https://crates.io/crates/ndarray-parallel
+
+Highlights
+----------
+
+- Parallel elementwise (no order) and axis iterators
+
+Status and Lookout
+------------------
+
+- Still iterating on and evolving the crate
+
+  + A separate crate is less convenient (doesn't use rayon IntoParallelIterator
+    trait, but a separate crate) but allows rapid iteration and we can follow
+    the evolution of rayon's internals.
+  + This crate is double pace: For every ndarray or rayon major version, this
+    crate goes up one major version.
+
+- Performance:
+
+  + TBD. Tell me about your experience.
+  + You'll need a big chunk of data (or an expensive operation per data point)
+    to gain from parallelization.
+
+How to use with cargo::
+
+    [dependencies]
+    ndarray-parallel = "0.1"
+
+Recent Changes (ndarray-parallel)
+---------------------------------
+
+- *
+
+  - Not yet released
+
+License
+=======
+
+Dual-licensed to be compatible with the Rust project.
+
+Licensed under the Apache License, Version 2.0
+http://www.apache.org/licenses/LICENSE-2.0 or the MIT license
+http://opensource.org/licenses/MIT, at your
+option. This file may not be copied, modified, or distributed
+except according to those terms.
+
+

--- a/parallel/benches/rayon.rs
+++ b/parallel/benches/rayon.rs
@@ -1,9 +1,11 @@
 
 #![feature(test)]
 
+extern crate num_cpus;
 extern crate test;
 use test::Bencher;
 
+extern crate rayon;
 #[macro_use(s)]
 extern crate ndarray;
 extern crate ndarray_parallel;
@@ -11,6 +13,14 @@ use ndarray::prelude::*;
 use ndarray_parallel::prelude::*;
 
 const EXP_N: usize = 128;
+
+use std::cmp::max;
+
+fn set_threads() {
+    let n = max(1, num_cpus::get() / 2);
+    let cfg = rayon::Configuration::new().set_num_threads(n);
+    let _ = rayon::initialize(cfg);
+}
 
 #[bench]
 fn map_exp_regular(bench: &mut Bencher)
@@ -25,6 +35,7 @@ fn map_exp_regular(bench: &mut Bencher)
 #[bench]
 fn rayon_exp_regular(bench: &mut Bencher)
 {
+    set_threads();
     let mut a = Array2::<f64>::zeros((EXP_N, EXP_N));
     a.swap_axes(0, 1);
     bench.iter(|| {
@@ -32,7 +43,7 @@ fn rayon_exp_regular(bench: &mut Bencher)
     });
 }
 
-const FASTEXP: usize = 900;
+const FASTEXP: usize = 800;
 
 #[inline]
 fn fastexp(x: f64) -> f64 {
@@ -44,7 +55,6 @@ fn fastexp(x: f64) -> f64 {
 fn map_fastexp_regular(bench: &mut Bencher)
 {
     let mut a = Array2::<f64>::zeros((FASTEXP, FASTEXP));
-    let mut a = a.slice_mut(s![.., ..-1]);
     bench.iter(|| {
         a.mapv_inplace(|x| fastexp(x))
     });
@@ -53,6 +63,27 @@ fn map_fastexp_regular(bench: &mut Bencher)
 #[bench]
 fn rayon_fastexp_regular(bench: &mut Bencher)
 {
+    set_threads();
+    let mut a = Array2::<f64>::zeros((FASTEXP, FASTEXP));
+    bench.iter(|| {
+        a.view_mut().into_par_iter().for_each(|x| *x = fastexp(*x));
+    });
+}
+
+#[bench]
+fn map_fastexp_cut(bench: &mut Bencher)
+{
+    let mut a = Array2::<f64>::zeros((FASTEXP, FASTEXP));
+    let mut a = a.slice_mut(s![.., ..-1]);
+    bench.iter(|| {
+        a.mapv_inplace(|x| fastexp(x))
+    });
+}
+
+#[bench]
+fn rayon_fastexp_cut(bench: &mut Bencher)
+{
+    set_threads();
     let mut a = Array2::<f64>::zeros((FASTEXP, FASTEXP));
     let mut a = a.slice_mut(s![.., ..-1]);
     bench.iter(|| {

--- a/parallel/benches/rayon.rs
+++ b/parallel/benches/rayon.rs
@@ -1,0 +1,61 @@
+
+#![feature(test)]
+
+extern crate test;
+use test::Bencher;
+
+#[macro_use(s)]
+extern crate ndarray;
+extern crate ndarray_parallel;
+use ndarray::prelude::*;
+use ndarray_parallel::prelude::*;
+
+const EXP_N: usize = 128;
+
+#[bench]
+fn map_exp_regular(bench: &mut Bencher)
+{
+    let mut a = Array2::<f64>::zeros((EXP_N, EXP_N));
+    a.swap_axes(0, 1);
+    bench.iter(|| {
+        a.mapv_inplace(|x| x.exp());
+    });
+}
+
+#[bench]
+fn rayon_exp_regular(bench: &mut Bencher)
+{
+    let mut a = Array2::<f64>::zeros((EXP_N, EXP_N));
+    a.swap_axes(0, 1);
+    bench.iter(|| {
+        a.view_mut().into_par_iter().for_each(|x| *x = x.exp());
+    });
+}
+
+const FASTEXP: usize = 900;
+
+#[inline]
+fn fastexp(x: f64) -> f64 {
+    let x = 1. + x/1024.;
+    x.powi(1024)
+}
+
+#[bench]
+fn map_fastexp_regular(bench: &mut Bencher)
+{
+    let mut a = Array2::<f64>::zeros((FASTEXP, FASTEXP));
+    let mut a = a.slice_mut(s![.., ..-1]);
+    bench.iter(|| {
+        a.mapv_inplace(|x| fastexp(x))
+    });
+}
+
+#[bench]
+fn rayon_fastexp_regular(bench: &mut Bencher)
+{
+    let mut a = Array2::<f64>::zeros((FASTEXP, FASTEXP));
+    let mut a = a.slice_mut(s![.., ..-1]);
+    bench.iter(|| {
+        a.view_mut().into_par_iter().for_each(|x| *x = fastexp(*x));
+    });
+}

--- a/parallel/benches/rayon.rs
+++ b/parallel/benches/rayon.rs
@@ -90,3 +90,25 @@ fn rayon_fastexp_cut(bench: &mut Bencher)
         a.view_mut().into_par_iter().for_each(|x| *x = fastexp(*x));
     });
 }
+
+#[bench]
+fn map_fastexp_by_axis(bench: &mut Bencher)
+{
+    let mut a = Array2::<f64>::zeros((FASTEXP, FASTEXP));
+    bench.iter(|| {
+        for mut sheet in a.axis_iter_mut(Axis(0)) {
+            sheet.mapv_inplace(fastexp)
+        }
+    });
+}
+
+#[bench]
+fn rayon_fastexp_by_axis(bench: &mut Bencher)
+{
+    set_threads();
+    let mut a = Array2::<f64>::zeros((FASTEXP, FASTEXP));
+    bench.iter(|| {
+        a.axis_iter_mut(Axis(0)).into_par_iter()
+            .for_each(|mut sheet| sheet.mapv_inplace(fastexp));
+    });
+}

--- a/parallel/src/into_impls.rs
+++ b/parallel/src/into_impls.rs
@@ -14,6 +14,7 @@ impl<'a, A, D> IntoParallelIterator for &'a Array<A, D>
     }
 }
 
+// This is allowed: goes through `.view()`
 impl<'a, A, D> IntoParallelIterator for &'a RcArray<A, D>
     where D: Dimension,
           A: Sync
@@ -36,6 +37,7 @@ impl<'a, A, D> IntoParallelIterator for &'a mut Array<A, D>
     }
 }
 
+// This is allowed: goes through `.view_mut()`, which is unique access
 impl<'a, A, D> IntoParallelIterator for &'a mut RcArray<A, D>
     where D: Dimension,
           A: Sync + Send + Clone,

--- a/parallel/src/into_impls.rs
+++ b/parallel/src/into_impls.rs
@@ -1,0 +1,48 @@
+use ndarray::{Array, RcArray, Dimension, ArrayView, ArrayViewMut};
+
+use NdarrayIntoParallelIterator as IntoParallelIterator;
+use Parallel;
+
+impl<'a, A, D> IntoParallelIterator for &'a Array<A, D>
+    where D: Dimension,
+          A: Sync
+{
+    type Item = &'a A;
+    type Iter = Parallel<ArrayView<'a, A, D>>;
+    fn into_par_iter(self) -> Self::Iter {
+        self.view().into_par_iter()
+    }
+}
+
+impl<'a, A, D> IntoParallelIterator for &'a RcArray<A, D>
+    where D: Dimension,
+          A: Sync
+{
+    type Item = &'a A;
+    type Iter = Parallel<ArrayView<'a, A, D>>;
+    fn into_par_iter(self) -> Self::Iter {
+        self.view().into_par_iter()
+    }
+}
+
+impl<'a, A, D> IntoParallelIterator for &'a mut Array<A, D>
+    where D: Dimension,
+          A: Sync + Send
+{
+    type Item = &'a mut A;
+    type Iter = Parallel<ArrayViewMut<'a, A, D>>;
+    fn into_par_iter(self) -> Self::Iter {
+        self.view_mut().into_par_iter()
+    }
+}
+
+impl<'a, A, D> IntoParallelIterator for &'a mut RcArray<A, D>
+    where D: Dimension,
+          A: Sync + Send + Clone,
+{
+    type Item = &'a mut A;
+    type Iter = Parallel<ArrayViewMut<'a, A, D>>;
+    fn into_par_iter(self) -> Self::Iter {
+        self.view_mut().into_par_iter()
+    }
+}

--- a/parallel/src/into_traits.rs
+++ b/parallel/src/into_traits.rs
@@ -1,0 +1,42 @@
+
+use rayon::par_iter::ParallelIterator;
+
+pub trait NdarrayIntoParallelIterator {
+    type Iter: ParallelIterator<Item=Self::Item>;
+    type Item: Send;
+    fn into_par_iter(self) -> Self::Iter;
+}
+
+pub trait NdarrayIntoParallelRefIterator<'x> {
+    type Iter: ParallelIterator<Item=Self::Item>;
+    type Item: Send + 'x;
+    fn par_iter(&'x self) -> Self::Iter;
+}
+
+pub trait NdarrayIntoParallelRefMutIterator<'x> {
+    type Iter: ParallelIterator<Item=Self::Item>;
+    type Item: Send + 'x;
+    fn par_iter_mut(&'x mut self) -> Self::Iter;
+}
+
+impl<'data, I: 'data + ?Sized> NdarrayIntoParallelRefIterator<'data> for I
+    where &'data I: NdarrayIntoParallelIterator
+{
+    type Iter = <&'data I as NdarrayIntoParallelIterator>::Iter;
+    type Item = <&'data I as NdarrayIntoParallelIterator>::Item;
+
+    fn par_iter(&'data self) -> Self::Iter {
+        self.into_par_iter()
+    }
+}
+
+impl<'data, I: 'data + ?Sized> NdarrayIntoParallelRefMutIterator<'data> for I
+    where &'data mut I: NdarrayIntoParallelIterator
+{
+    type Iter = <&'data mut I as NdarrayIntoParallelIterator>::Iter;
+    type Item = <&'data mut I as NdarrayIntoParallelIterator>::Item;
+
+    fn par_iter_mut(&'data mut self) -> Self::Iter {
+        self.into_par_iter()
+    }
+}

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+    }
+}

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -61,7 +61,7 @@ pub mod prelude {
     pub use NdarrayIntoParallelRefMutIterator;
 
     #[doc(no_inline)]
-    pub use rayon::prelude::{ParallelIterator, ExactParallelIterator};
+    pub use rayon::prelude::{ParallelIterator, IndexedParallelIterator, ExactParallelIterator};
 }
 
 pub use par::Parallel;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -48,22 +48,25 @@
 
 
 extern crate ndarray;
-pub extern crate rayon;
-
-use rayon::par_iter::ParallelIterator;
+extern crate rayon;
 
 pub mod prelude {
+    // happy and insane; ignorance is bluss
     pub use NdarrayIntoParallelIterator;
-    #[doc(no_inline)]
-    pub use rayon::prelude::{ParallelIterator};
-}
+    pub use NdarrayIntoParallelRefIterator;
+    pub use NdarrayIntoParallelRefMutIterator;
 
-pub trait NdarrayIntoParallelIterator {
-    type Iter: ParallelIterator<Item=Self::Item>;
-    type Item: Send;
-    fn into_par_iter(self) -> Self::Iter;
+    #[doc(no_inline)]
+    pub use rayon::prelude::{ParallelIterator, ExactParallelIterator};
 }
 
 pub use par::Parallel;
+pub use into_traits::{
+    NdarrayIntoParallelIterator,
+    NdarrayIntoParallelRefIterator,
+    NdarrayIntoParallelRefMutIterator,
+};
 
 mod par;
+mod into_traits;
+mod into_impls;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1,8 +1,14 @@
 
 extern crate ndarray;
-extern crate rayon;
+pub extern crate rayon;
 
 use rayon::par_iter::ParallelIterator;
+
+pub mod prelude {
+    pub use NdarrayIntoParallelIterator;
+    #[doc(no_inline)]
+    pub use rayon::prelude::{ParallelIterator};
+}
 
 pub trait NdarrayIntoParallelIterator {
     type Iter: ParallelIterator<Item=Self::Item>;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1,6 +1,15 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-    }
+
+extern crate ndarray;
+extern crate rayon;
+
+use rayon::par_iter::ParallelIterator;
+
+pub trait NdarrayIntoParallelIterator {
+    type Iter: ParallelIterator<Item=Self::Item>;
+    type Item: Send;
+    fn into_par_iter(self) -> Self::Iter;
 }
+
+pub use par::Parallel;
+
+mod par;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1,11 +1,14 @@
 //! Parallelization features for ndarray.
 //!
 //! The array views and references to owned arrays all implement
-//! `IntoParallelIterator`; the default parallel iterators (each element by
-//! reference or mutable reference) have no ordering guarantee in their parallel
-//! implementations.
+//! `NdarrayIntoParallelIterator` (*); the default parallel iterators (each element
+//! by reference or mutable reference) have no ordering guarantee in their
+//! parallel implementations.
 //!
 //! `.axis_iter()` and `.axis_iter_mut()` also have parallel counterparts.
+//!
+//! (*) This regime of a custom trait instead of rayon’s own is since we
+//! use this intermediate ndarray-parallel crate.
 //!
 //! # Examples
 //!
@@ -50,6 +53,7 @@
 extern crate ndarray;
 extern crate rayon;
 
+/// Into- traits for creating parallelized iterators.
 pub mod prelude {
     // happy and insane; ignorance is bluss
     pub use NdarrayIntoParallelIterator;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1,3 +1,51 @@
+//! Parallelization features for ndarray.
+//!
+//! The array views and references to owned arrays all implement
+//! `IntoParallelIterator`; the default parallel iterators (each element by
+//! reference or mutable reference) have no ordering guarantee in their parallel
+//! implementations.
+//!
+//! `.axis_iter()` and `.axis_iter_mut()` also have parallel counterparts.
+//!
+//! # Examples
+//!
+//! Compute the exponential of each element in an array, parallelized.
+//!
+//! ```
+//! extern crate ndarray;
+//! extern crate ndarray_parallel;
+//!
+//! use ndarray::Array2;
+//! use ndarray_parallel::prelude::*;
+//!
+//! fn main() {
+//!     let mut a = Array2::<f64>::zeros((128, 128));
+//!     a.par_iter_mut().for_each(|x| *x = x.exp());
+//! }
+//! ```
+//!
+//! Use the parallel `.axis_iter()` to compute the sum of each row.
+//!
+//! ```
+//! extern crate ndarray;
+//! extern crate ndarray_parallel;
+//!
+//! use ndarray::Array;
+//! use ndarray::Axis;
+//! use ndarray_parallel::prelude::*;
+//!
+//! fn main() {
+//!     let a = Array::linspace(0., 63., 64).into_shape((4, 16)).unwrap();
+//!     let mut sums = Vec::new();
+//!     a.axis_iter(Axis(0))
+//!      .into_par_iter()
+//!      .map(|row| row.scalar_sum())
+//!      .collect_into(&mut sums);
+//!
+//!     assert_eq!(sums, [120., 376., 632., 888.]);
+//! }
+//! ```
+
 
 extern crate ndarray;
 pub extern crate rayon;

--- a/parallel/src/par.rs
+++ b/parallel/src/par.rs
@@ -1,0 +1,133 @@
+
+use rayon::par_iter::ParallelIterator;
+use rayon::par_iter::IndexedParallelIterator;
+use rayon::par_iter::ExactParallelIterator;
+use rayon::par_iter::BoundedParallelIterator;
+use rayon::par_iter::internal::{Consumer, UnindexedConsumer};
+use rayon::par_iter::internal::bridge;
+use rayon::par_iter::internal::ProducerCallback;
+use rayon::par_iter::internal::Producer;
+
+use ndarray::AxisIter;
+use ndarray::AxisIterMut;
+use ndarray::{Dimension};
+
+use super::NdarrayIntoParallelIterator;
+
+/// Parallel iterator wrapper.
+#[derive(Copy, Clone, Debug)]
+pub struct Parallel<I> {
+    iter: I,
+}
+
+/// Parallel producer wrapper.
+#[derive(Copy, Clone, Debug)]
+struct ParallelProducer<I>(I);
+
+impl<I> From<I> for Parallel<I::IntoIter>
+    where I: IntoIterator,
+{
+    fn from(iter: I) -> Self {
+        Parallel {
+            iter: iter.into_iter()
+        }
+    }
+}
+
+macro_rules! par_iter_wrapper {
+    // thread_bounds are either Sync or Send + Sync
+    ($iter_name:ident, [$($thread_bounds:tt)*]) => {
+    impl<'a, A, D> NdarrayIntoParallelIterator for $iter_name<'a, A, D>
+        where D: Dimension,
+              A: $($thread_bounds)*,
+    {
+        type Item = <Self as Iterator>::Item;
+        type Iter = Parallel<Self>;
+        fn into_par_iter(self) -> Self::Iter {
+            Parallel::from(self)
+        }
+    }
+
+    impl<'a, A, D> ParallelIterator for Parallel<$iter_name<'a, A, D>>
+        where D: Dimension,
+              A: $($thread_bounds)*,
+    {
+        type Item = <$iter_name<'a, A, D> as Iterator>::Item;
+        fn drive_unindexed<C>(self, consumer: C) -> C::Result
+            where C: UnindexedConsumer<Self::Item>
+        {
+            bridge(self, consumer)
+        }
+    }
+
+    impl<'a, A, D> IndexedParallelIterator for Parallel<$iter_name<'a, A, D>>
+        where D: Dimension,
+              A: $($thread_bounds)*,
+    {
+        fn with_producer<Cb>(self, callback: Cb) -> Cb::Output
+            where Cb: ProducerCallback<Self::Item>
+        {
+            callback.callback(ParallelProducer(self.iter))
+        }
+    }
+
+    impl<'a, A, D> ExactParallelIterator for Parallel<$iter_name<'a, A, D>>
+        where D: Dimension,
+              A: $($thread_bounds)*,
+    {
+        fn len(&mut self) -> usize {
+            ExactSizeIterator::len(&self.iter)
+        }
+    }
+
+    impl<'a, A, D> BoundedParallelIterator for Parallel<$iter_name<'a, A, D>>
+        where D: Dimension,
+              A: $($thread_bounds)*,
+    {
+        fn upper_bound(&mut self) -> usize {
+            ExactSizeIterator::len(&self.iter)
+        }
+
+        fn drive<C>(self, consumer: C) -> C::Result
+            where C: Consumer<Self::Item>
+        {
+            bridge(self, consumer)
+        }
+    }
+
+    impl<'a, A, D> Iterator for ParallelProducer<$iter_name<'a, A, D>>
+        where D: Dimension,
+    {
+        type Item = <$iter_name<'a, A, D> as Iterator>::Item;
+        #[inline(always)]
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            self.0.size_hint()
+        }
+    }
+
+    // This is the real magic, I guess
+    impl<'a, A, D> Producer for ParallelProducer<$iter_name<'a, A, D>>
+        where D: Dimension,
+              A: $($thread_bounds)*,
+    {
+        fn cost(&mut self, len: usize) -> f64 {
+            // FIXME: No idea about what this is
+            len as f64
+        }
+
+        fn split_at(self, i: usize) -> (Self, Self) {
+            let (a, b) = self.0.split_at(i);
+            (ParallelProducer(a), ParallelProducer(b))
+        }
+    }
+
+    }
+}
+
+
+par_iter_wrapper!(AxisIter, [Sync]);
+par_iter_wrapper!(AxisIterMut, [Send + Sync]);

--- a/parallel/tests/rayon.rs
+++ b/parallel/tests/rayon.rs
@@ -30,7 +30,6 @@ fn test_axis_iter_mut() {
     assert!(a.all_close(&b, 0.001));
 }
 
-/*
 #[test]
 fn test_regular_iter() {
     let mut a = Array2::<f64>::zeros((M, N));
@@ -41,4 +40,3 @@ fn test_regular_iter() {
     println!("{:?}", a.slice(s![..10, ..5]));
     assert_eq!(s, a.scalar_sum());
 }
-*/

--- a/parallel/tests/rayon.rs
+++ b/parallel/tests/rayon.rs
@@ -1,0 +1,44 @@
+
+extern crate rayon;
+#[macro_use(s)] extern crate ndarray;
+extern crate ndarray_parallel;
+
+use ndarray::prelude::*;
+use ndarray_parallel::prelude::*;
+
+const M: usize = 1024 * 10;
+const N: usize = 100;
+
+#[test]
+fn test_axis_iter() {
+    let mut a = Array2::<f64>::zeros((M, N));
+    for (i, mut v) in a.axis_iter_mut(Axis(0)).enumerate() {
+        v.fill(i as _);
+    }
+    assert_eq!(a.axis_iter(Axis(0)).len(), M);
+    let s = a.axis_iter(Axis(0)).into_par_iter().map(|x| x.scalar_sum()).sum();
+    println!("{:?}", a.slice(s![..10, ..5]));
+    assert_eq!(s, a.scalar_sum());
+}
+
+#[test]
+fn test_axis_iter_mut() {
+    let mut a = Array::linspace(0., 1.0f64, M * N).into_shape((M, N)).unwrap();
+    let b = a.mapv(|x| x.exp());
+    a.axis_iter_mut(Axis(0)).into_par_iter().for_each(|mut v| v.mapv_inplace(|x| x.exp()));
+    println!("{:?}", a.slice(s![..10, ..5]));
+    assert!(a.all_close(&b, 0.001));
+}
+
+/*
+#[test]
+fn test_regular_iter() {
+    let mut a = Array2::<f64>::zeros((M, N));
+    for (i, mut v) in a.axis_iter_mut(Axis(0)).enumerate() {
+        v.fill(i as _);
+    }
+    let s = a.view().into_par_iter().map(|&x| x).sum();
+    println!("{:?}", a.slice(s![..10, ..5]));
+    assert_eq!(s, a.scalar_sum());
+}
+*/


### PR DESCRIPTION
- new crate `ndarray-parallel` that pulls in both rayon and ndarray
- This is strategy (2) (See https://github.com/nikomatsakis/rayon/pull/188#issuecomment-269633834)
- This is a separate crate until rayon clarifies its version story somewhat.