### PR TITLE
Implement Clone::clone_from for ArrayBase

### DIFF
--- a/src/impl_clone.rs
+++ b/src/impl_clone.rs
@@ -20,6 +20,17 @@ impl<S: DataClone, D: Clone> Clone for ArrayBase<S, D> {
             }
         }
     }
+
+    /// `Array` implements `.clone_from()` to reuse an array's existing
+    /// allocation. Semantically equivalent to `*self = other.clone()`, but
+    /// potentially more efficient.
+    fn clone_from(&mut self, other: &Self) {
+        unsafe {
+            self.ptr = self.data.clone_from_with_ptr(&other.data, other.ptr);
+            self.dim.clone_from(&other.dim);
+            self.strides.clone_from(&other.strides);
+        }
+    }
 }
 
 impl<S: DataClone + Copy, D: Copy> Copy for ArrayBase<S, D> {}

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -1,0 +1,20 @@
+
+extern crate ndarray;
+
+use ndarray::arr2;
+
+#[test]
+fn test_clone_from() {
+    let a = arr2(&[[1, 2, 3],
+                   [4, 5, 6],
+                   [7, 8, 9]]);
+    let b = arr2(&[[7, 7, 7]]);
+    let mut c = b.clone();
+    c.clone_from(&a);
+    assert_eq!(a, c);
+
+    let mut bv = b.view();
+    bv.clone_from(&a.view());
+    assert_eq!(&a, &bv);
+
+}


### PR DESCRIPTION
This reuses Vec's .clone_from() in `Array`. No effect for ArrayView or
RcArray, of course.