### PR TITLE
Use axpy for scaled_add

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -457,17 +457,31 @@ fn iadd_2d_strided(bench: &mut test::Bencher)
     });
 }
 
+const SCALE_ADD_SZ: usize = 64;
+
 #[bench]
 fn scaled_add_2d_f32_regular(bench: &mut test::Bencher)
 {
-    let mut av = Array::<f32, _>::zeros((64, 64));
-    let bv = Array::<f32, _>::zeros((64, 64));
+    let mut av = Array::<f32, _>::zeros((SCALE_ADD_SZ, SCALE_ADD_SZ));
+    let bv = Array::<f32, _>::zeros((SCALE_ADD_SZ, SCALE_ADD_SZ));
     let scalar = 3.1415926535;
     bench.iter(|| {
         av.scaled_add(scalar, &bv);
     });
 }
 
+#[bench]
+fn scaled_add_2d_f32_stride(bench: &mut test::Bencher)
+{
+    let mut av = Array::<f32, _>::zeros((SCALE_ADD_SZ, 2 * SCALE_ADD_SZ));
+    let bv = Array::<f32, _>::zeros((SCALE_ADD_SZ, 2 * SCALE_ADD_SZ));
+    let mut av = av.slice_mut(s![.., ..;2]);
+    let bv = bv.slice(s![.., ..;2]);
+    let scalar = 3.1415926535;
+    bench.iter(|| {
+        av.scaled_add(scalar, &bv);
+    });
+}
 
 #[bench]
 fn assign_scalar_2d_corder(bench: &mut test::Bencher)

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -1,6 +1,7 @@
 #![feature(test)]
 #![allow(unused_imports)]
 
+extern crate blas_sys;
 extern crate test;
 #[macro_use(s)]
 extern crate ndarray;
@@ -467,6 +468,18 @@ fn scaled_add_2d_f32_regular(bench: &mut test::Bencher)
         av.scaled_add(scalar, &bv);
     });
 }
+
+#[bench]
+fn scaled_add_2d_f32_axpy(bench: &mut test::Bencher)
+{
+    let mut av = Array::<f32, _>::zeros((64, 64));
+    let bv = Array::<f32, _>::zeros((64, 64));
+    let scalar = 3.1415926535;
+    bench.iter(|| {
+        av.scaled_add_axpy(scalar, &bv);
+    });
+}
+
 
 #[bench]
 fn assign_scalar_2d_corder(bench: &mut test::Bencher)

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 #![allow(unused_imports)]
 
-extern crate blas_sys;
 extern crate test;
 #[macro_use(s)]
 extern crate ndarray;
@@ -466,17 +465,6 @@ fn scaled_add_2d_f32_regular(bench: &mut test::Bencher)
     let scalar = 3.1415926535;
     bench.iter(|| {
         av.scaled_add(scalar, &bv);
-    });
-}
-
-#[bench]
-fn scaled_add_2d_f32_axpy(bench: &mut test::Bencher)
-{
-    let mut av = Array::<f32, _>::zeros((64, 64));
-    let bv = Array::<f32, _>::zeros((64, 64));
-    let scalar = 3.1415926535;
-    bench.iter(|| {
-        av.scaled_add_axpy(scalar, &bv);
     });
 }
 

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -280,7 +280,7 @@ pub unsafe trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
     ///
     /// Returns `Some(n)` if the strides in all dimensions are equispaced. Returns `None` if not.
     #[doc(hidden)]
-    fn equispaced_stride(dim: &Self, strides: &Self) -> Option<usize> {
+    fn equispaced_stride(dim: &Self, strides: &Self) -> Option<isize> {
         let order = strides._fastest_varying_stride_order();
         let base_stride = strides[order[0]];
 
@@ -295,7 +295,8 @@ pub unsafe trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
             }
             next_stride *= dim_slice[i];
         }
-        Some(base_stride)
+
+       Some(base_stride as isize)
     }
 
     /// Return the axis ordering corresponding to the fastest variation

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -269,20 +269,33 @@ pub unsafe trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
             return true;
         }
         if dim.ndim() == 1 { return false; }
+
+        match Self::equispaced_stride(dim, strides) {
+            Some(1) => true,
+            _ => false,
+        }
+    }
+
+    /// Return the equispaced stride between all the array elements.
+    ///
+    /// Returns `Some(n)` if the strides in all dimensions are equispaced. Returns `None` if not.
+    #[doc(hidden)]
+    fn equispaced_stride(dim: &Self, strides: &Self) -> Option<usize> {
         let order = strides._fastest_varying_stride_order();
-        let strides = strides.slice();
+        let base_stride = strides[order[0]];
 
         // FIXME: Negative strides
         let dim_slice = dim.slice();
-        let mut cstride = 1;
+        let mut next_stride = base_stride;
+        let strides = strides.slice();
         for &i in order.slice() {
             // a dimension of length 1 can have unequal strides
-            if dim_slice[i] != 1 && strides[i] != cstride {
-                return false;
+            if dim_slice[i] != 1 && strides[i] != next_stride {
+                return None;
             }
-            cstride *= dim_slice[i];
+            next_stride *= dim_slice[i];
         }
-        true
+        Some(base_stride)
     }
 
     /// Return the axis ordering corresponding to the fastest variation

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -295,6 +295,60 @@ impl<A, S, D> ArrayBase<S, D>
     {
         self.zip_mut_with(rhs, move |y, &x| *y = *y + (alpha * x));
     }
+
+    /// Perform the operation `self += alpha * rhs` efficiently, where
+    /// `alpha` is a scalar and `rhs` is another array. This operation is
+    /// also known as `axpy` in BLAS.
+    ///
+    /// If their shapes disagree, `rhs` is broadcast to the shape of `self`.
+    ///
+    /// **Panics** if broadcasting isn’t possible.
+    #[cfg(feature="blas")]
+    pub fn scaled_add_axpy<S2, E>(&mut self, alpha: A, rhs: &ArrayBase<S2, E>)
+        where S: DataMut,
+              S2: Data<Elem=A>,
+              A: LinalgScalar + ::std::fmt::Debug,
+              E: Dimension,
+    {
+        debug_assert_eq!(self.len(), rhs.len());
+        assert!(self.len() == rhs.len());
+
+        {
+            macro_rules! axpy {
+                ($ty:ty, $func:ident) => {{
+            if blas_compat::<$ty, _, _>(self) && blas_compat::<$ty, _, _>(rhs) {
+                let order = Dimension::_fastest_varying_stride_order(&self.strides);
+                let incx = self.strides()[order[0]];
+
+                let order = Dimension::_fastest_varying_stride_order(&rhs.strides);
+                let incy = self.strides()[order[0]];
+
+                unsafe {
+                    let (lhs_ptr, n, incx) = blas_1d_params(self.ptr,
+                                                            self.len(),
+                                                            incx);
+                    let (rhs_ptr, _, incy) = blas_1d_params(rhs.ptr,
+                                                            rhs.len(),
+                                                            incy);
+                    blas_sys::c::$func(
+                        n,
+                        cast_as(&alpha),
+                        rhs_ptr as *const $ty,
+                        incy,
+                        lhs_ptr as *mut $ty,
+                        incx);
+                    return;
+                }
+            }
+                }}
+            }
+
+            axpy!{f32, cblas_saxpy};
+            axpy!{f64, cblas_daxpy};
+        }
+
+        self.scaled_add(alpha, rhs);
+    }
 }
 
 // mat_mul_impl uses ArrayView arguments to send all array kinds into
@@ -527,6 +581,35 @@ fn blas_compat_1d<A, S>(a: &ArrayBase<S, Ix1>) -> bool
     if stride > blas_index::max_value() as isize ||
         stride < blas_index::min_value() as isize {
         return false;
+    }
+    true
+}
+
+#[cfg(feature="blas")]
+fn blas_compat<A, S, D>(a: &ArrayBase<S, D>) -> bool
+    where S: Data,
+          A: 'static,
+          S::Elem: 'static,
+          D: Dimension,
+{
+    if !same_type::<A, S::Elem>() {
+        return false;
+    }
+
+    if a.len() > blas_index::max_value() as usize {
+        return false;
+    }
+
+    match D::equispaced_stride(&a.raw_dim(), &a.strides) {
+        Some(stride) => {
+            if stride > blas_index::max_value() as isize ||
+                stride < blas_index::min_value() as isize {
+                return false;
+            }
+        },
+        None => {
+            return false;
+        }
     }
     true
 }

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -43,6 +43,18 @@ fn dyn_dimension()
 }
 
 #[test]
+fn equidistance_strides() {
+    let strides = Dim([4,2,1]);
+    assert_eq!(Dimension::equispaced_stride(&Dim([2,2,2]), &strides), Some(1));
+
+    let strides = Dim([8,4,2]);
+    assert_eq!(Dimension::equispaced_stride(&Dim([2,2,2]), &strides), Some(2));
+
+    let strides = Dim([16,4,1]);
+    assert_eq!(Dimension::equispaced_stride(&Dim([2,2,2]), &strides), None);
+}
+
+#[test]
 fn fastest_varying_order() {
     let strides = Dim([2, 8, 4, 1]);
     let order = strides._fastest_varying_stride_order();

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -459,6 +459,22 @@ fn scaled_add() {
 
 }
 
+#[cfg(blas)]
+#[test]
+fn scaled_add_axpy() {
+    let a = range_mat(16, 15);
+    let mut b = range_mat(16, 15);
+    b.mapv_inplace(f32::exp);
+
+    let alpha = 0.2_f32;
+    let mut c = a.clone();
+    c.scaled_add(alpha, &b);
+
+    let mut d = a.clone();
+    d.scaled_add_axpy(alpha, &b);
+    assert_eq!(c, d);
+}
+
 #[test]
 fn gen_mat_mul() {
     let alpha = -2.3;

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -459,22 +459,6 @@ fn scaled_add() {
 
 }
 
-#[cfg(blas)]
-#[test]
-fn scaled_add_axpy() {
-    let a = range_mat(16, 15);
-    let mut b = range_mat(16, 15);
-    b.mapv_inplace(f32::exp);
-
-    let alpha = 0.2_f32;
-    let mut c = a.clone();
-    c.scaled_add(alpha, &b);
-
-    let mut d = a.clone();
-    d.scaled_add_axpy(alpha, &b);
-    assert_eq!(c, d);
-}
-
 #[test]
 fn gen_mat_mul() {
     let alpha = -2.3;


### PR DESCRIPTION
This adds a method to use `saxpy` and `daxpy` when doing scaled addition. It gives a nice performance boost:

```
test scaled_add_2d_f32_axpy           ... bench:         312 ns/iter (+/- 13)
test scaled_add_2d_f32_regular        ... bench:         571 ns/iter (+/- 23)
```

The main addition in this code is `Dimension::equispaced_stride`, which is a generalization of the code formerly inside `Dimension::is_contiguous`: if all elements of an array are one ptr-width away from each other, we call the array *contiguous*. If all elements of an array are exactly `n` ptr-widths away from each other, we call the array *equispaced* (not sure if that's the right terminology). If `n = 1`, then an equispaced array is contiguous. As long as an array is equispaced, it is admissable to blas via the `incx` and `incy` variables (in case of `*axpy`).

I think we might be able to use this for the `gemm` implementations, too.


**EDIT:** I notice that there are inlined versions of the `Dimensions` trait functions for 1 to 3 dimensional arrays. I guess I should extend those too?

**EDIT 2:** I am also not sure I like the extra allocations in that continuity/equidistance check. But I guess it doesn't matter much for large arrays.