### PR TITLE
Rayon parallelization for Zip / azip!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
       cargo test --release --verbose --no-default-features &&
       cargo build --verbose --features "$FEATURES" &&
       cargo test --verbose --features "$FEATURES" &&
+      CARGO_TARGET_DIR=target/ cargo test --manifest-path=parallel/Cargo.toml --verbose &&
       CARGO_TARGET_DIR=target/ cargo test --manifest-path=serialization-tests/Cargo.toml --verbose &&
       CARGO_TARGET_DIR=target/ cargo test --manifest-path=numeric-tests/Cargo.toml --verbose &&
-      CARGO_TARGET_DIR=target/ cargo test --manifest-path=parallel/Cargo.toml --verbose &&
       ([ "$BENCH" != 1 ] || cargo bench --no-run --verbose --features "$FEATURES")

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["data-structure", "multidimensional", "parallel", "concurrent"]
 categories = ["data-structures", "science", "concurrency"]
 
 [dependencies]
-rayon = "0.6"
+rayon = { version = "0.7.0" }
 ndarray = { version = "0.9.0-alpha.1", path = "../" }
 
 [dev-dependencies]

--- a/parallel/README.rst
+++ b/parallel/README.rst
@@ -47,6 +47,11 @@ How to use with cargo::
 Recent Changes (ndarray-parallel)
 ---------------------------------
 
+- (Not Yet Released)
+
+  - ParallelIterator for Zip
+  - Require next version of rayon
+
 - 0.2.0
 
   - Require for ndarray 0.8

--- a/parallel/README.rst
+++ b/parallel/README.rst
@@ -47,10 +47,11 @@ How to use with cargo::
 Recent Changes (ndarray-parallel)
 ---------------------------------
 
-- (Not Yet Released)
+- 0.3.0-alpha.1
 
-  - ParallelIterator for Zip
-  - Require next version of rayon
+  - ParallelIterator for Zip, including ``.par_apply``.
+  - ``.par_map_inplace`` and ``.par_mav_inplace`` for arrays
+  - Require ndarray 0.9 (when released) and rayon 0.7
 
 - 0.2.0
 

--- a/parallel/src/ext_traits.rs
+++ b/parallel/src/ext_traits.rs
@@ -1,0 +1,44 @@
+
+use ndarray::{
+    Dimension,
+    NdProducer,
+    Zip,
+};
+
+use prelude::*;
+
+macro_rules! zip_impl {
+    ($([$name:ident $($p:ident)*],)+) => {
+        $(
+        /// The `par_apply` method for `Zip`.
+        ///
+        /// This is a shorthand for using `.into_par_iter().for_each()` on
+        /// `Zip`.
+        pub trait $name<$($p),*> {
+            fn par_apply<F>(self, function: F)
+                where F: Fn($($p),*) + Sync;
+        }
+
+        #[allow(non_snake_case)]
+        impl<Dim: Dimension, $($p: NdProducer<Dim=Dim>),*> $name<$($p::Item),*> for Zip<($($p,)*), Dim>
+            where $($p::Item : Send , )*
+                  $($p : Send , )*
+        {
+            fn par_apply<F>(self, function: F)
+                where F: Fn($($p::Item),*) + Sync
+            {
+                self.into_par_iter().for_each(move |($($p,)*)| function($($p),*))
+            }
+        }
+        )+
+    }
+}
+
+zip_impl!{
+    [ParApply1 P1],
+    [ParApply2 P1 P2],
+    [ParApply3 P1 P2 P3],
+    [ParApply4 P1 P2 P3 P4],
+    [ParApply5 P1 P2 P3 P4 P5],
+    [ParApply6 P1 P2 P3 P4 P5 P6],
+}

--- a/parallel/src/into_traits.rs
+++ b/parallel/src/into_traits.rs
@@ -1,5 +1,5 @@
 
-use rayon::par_iter::ParallelIterator;
+use rayon::iter::ParallelIterator;
 
 pub trait NdarrayIntoParallelIterator {
     type Iter: ParallelIterator<Item=Self::Item>;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -52,7 +52,7 @@
 
 
 extern crate ndarray;
-extern crate rayon;
+pub extern crate rayon;
 
 /// Into- traits for creating parallelized iterators.
 pub mod prelude {

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -30,6 +30,12 @@
 //!
 //! fn main() {
 //!     let mut a = Array2::<f64>::zeros((128, 128));
+//!
+//!     // Parallel versions of regular array methods (ParMap trait)
+//!     a.par_map_inplace(|x| *x = x.exp());
+//!     a.par_mapv_inplace(f64::exp);
+//!
+//!     // You can also use the parallel iterator directly
 //!     a.par_iter_mut().for_each(|x| *x = x.exp());
 //! }
 //! ```
@@ -109,6 +115,7 @@ pub mod prelude {
         ParApply5,
         ParApply6,
     };
+    pub use ext_traits::ParMap;
 }
 
 pub use par::Parallel;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -8,10 +8,16 @@
 //! `.axis_iter()` and `.axis_iter_mut()` also have parallel counterparts,
 //! and their parallel iterators are indexed (and thus ordered) and exact length.
 //!
+//! `Zip` also implements `NdarrayIntoParallelIterator`, and there is an
+//! extension trait so that it can use a method `.par_apply` directly.
+//!
 //! (*) This regime of a custom trait instead of rayon’s own is since we
 //! use this intermediate ndarray-parallel crate.
 //!
 //! # Examples
+//!
+//!
+//! ## Arrays and array views
 //!
 //! Compute the exponential of each element in an array, parallelized.
 //!
@@ -27,6 +33,8 @@
 //!     a.par_iter_mut().for_each(|x| *x = x.exp());
 //! }
 //! ```
+//!
+//! ## Axis iterators
 //!
 //! Use the parallel `.axis_iter()` to compute the sum of each row.
 //!
@@ -47,6 +55,35 @@
 //!      .collect_into(&mut sums);
 //!
 //!     assert_eq!(sums, [120., 376., 632., 888.]);
+//! }
+//! ```
+//!
+//! ## Zip
+//!
+//! Use zip for lock step function application across several arrays
+//!
+//! ```
+//! extern crate ndarray;
+//! extern crate ndarray_parallel;
+//!
+//! use ndarray::Array3;
+//! use ndarray::Zip;
+//! use ndarray_parallel::prelude::*;
+//!
+//! type Array3f64 = Array3<f64>;
+//!
+//! fn main() {
+//!     const N: usize = 128;
+//!     let a = Array3f64::from_elem((N, N, N), 1.);
+//!     let b = Array3f64::from_elem(a.dim(), 2.);
+//!     let mut c = Array3f64::zeros(a.dim());
+//!
+//!     Zip::from(&mut c)
+//!         .and(&a)
+//!         .and(&b)
+//!         .par_apply(|c, &a, &b| {
+//!             *c += a - b;
+//!         });
 //! }
 //! ```
 

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -63,6 +63,15 @@ pub mod prelude {
 
     #[doc(no_inline)]
     pub use rayon::prelude::{ParallelIterator, IndexedParallelIterator, ExactParallelIterator};
+
+    pub use ext_traits::{
+        ParApply1,
+        ParApply2,
+        ParApply3,
+        ParApply4,
+        ParApply5,
+        ParApply6,
+    };
 }
 
 pub use par::Parallel;
@@ -73,5 +82,6 @@ pub use into_traits::{
 };
 
 mod par;
+mod ext_traits;
 mod into_traits;
 mod into_impls;

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -51,7 +51,7 @@
 //! ```
 
 
-extern crate ndarray;
+pub extern crate ndarray;
 pub extern crate rayon;
 
 /// Into- traits for creating parallelized iterators.

--- a/parallel/tests/rayon.rs
+++ b/parallel/tests/rayon.rs
@@ -16,7 +16,7 @@ fn test_axis_iter() {
         v.fill(i as _);
     }
     assert_eq!(a.axis_iter(Axis(0)).len(), M);
-    let s = a.axis_iter(Axis(0)).into_par_iter().map(|x| x.scalar_sum()).sum();
+    let s: f64 = a.axis_iter(Axis(0)).into_par_iter().map(|x| x.scalar_sum()).sum();
     println!("{:?}", a.slice(s![..10, ..5]));
     assert_eq!(s, a.scalar_sum());
 }
@@ -36,7 +36,7 @@ fn test_regular_iter() {
     for (i, mut v) in a.axis_iter_mut(Axis(0)).enumerate() {
         v.fill(i as _);
     }
-    let s = a.view().into_par_iter().map(|&x| x).sum();
+    let s: f64 = a.view().into_par_iter().map(|&x| x).sum();
     println!("{:?}", a.slice(s![..10, ..5]));
     assert_eq!(s, a.scalar_sum());
 }

--- a/parallel/tests/zip.rs
+++ b/parallel/tests/zip.rs
@@ -1,0 +1,83 @@
+
+extern crate ndarray;
+extern crate ndarray_parallel;
+
+use ndarray::prelude::*;
+use ndarray_parallel::prelude::*;
+
+use ndarray::Zip;
+
+const M: usize = 1024 * 10;
+const N: usize = 100;
+
+#[test]
+fn test_zip_1() {
+    let mut a = Array2::<f64>::zeros((M, N));
+
+    Zip::from(&mut a)
+        .par_apply(|x| {
+            *x = x.exp()
+        });
+}
+
+#[test]
+fn test_zip_index_1() {
+    let mut a = Array2::default((10, 10));
+
+    Zip::indexed(&mut a)
+        .par_apply(|i, x| {
+            *x = i;
+        });
+
+    for (i, elt) in a.indexed_iter() {
+        assert_eq!(*elt, i);
+    }
+}
+
+#[test]
+fn test_zip_index_2() {
+    let mut a = Array2::default((M, N));
+
+    Zip::indexed(&mut a)
+        .par_apply(|i, x| {
+            *x = i;
+        });
+
+    for (i, elt) in a.indexed_iter() {
+        assert_eq!(*elt, i);
+    }
+}
+
+#[test]
+fn test_zip_index_3() {
+    let mut a = Array::default((1, 2, 1, 2, 3));
+
+    Zip::indexed(&mut a)
+        .par_apply(|i, x| {
+            *x = i;
+        });
+
+    for (i, elt) in a.indexed_iter() {
+        assert_eq!(*elt, i);
+    }
+}
+
+#[test]
+fn test_zip_index_4() {
+    let mut a = Array2::zeros((M, N));
+    let mut b = Array2::zeros((M, N));
+
+    Zip::indexed(&mut a)
+        .and(&mut b)
+        .par_apply(|(i, j), x, y| {
+            *x = i;
+            *y = j;
+        });
+
+    for ((i, _), elt) in a.indexed_iter() {
+        assert_eq!(*elt, i);
+    }
+    for ((_, j), elt) in b.indexed_iter() {
+        assert_eq!(*elt, j);
+    }
+}


### PR DESCRIPTION
Fixes #279 

- With this, `Zip` is parallelized, including `Zip::indexed`.
- Also add extension methods `par_map_inplace` and `.par_mapv_inplace` to arrays.