### PR TITLE
Fix a bug in Zip with 3D arrays in uncommon memory layout

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -527,23 +527,46 @@ fn add_2d_zip_strided(bench: &mut test::Bencher)
 }
 
 #[bench]
-fn add_2d_transposed(bench: &mut test::Bencher)
+fn add_2d_one_transposed(bench: &mut test::Bencher)
 {
     let mut a = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     a.swap_axes(0, 1);
     let b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
-    let bv = b.view();
     bench.iter(|| {
-        a += &bv;
+        a += &b;
     });
 }
 
 #[bench]
-fn add_2d_zip_transposed(bench: &mut test::Bencher)
+fn add_2d_zip_one_transposed(bench: &mut test::Bencher)
 {
     let mut a = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
     a.swap_axes(0, 1);
     let b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
+    bench.iter(|| {
+        Zip::from(&mut a).and(&b).apply(|a, &b| *a += b);
+    });
+}
+
+#[bench]
+fn add_2d_both_transposed(bench: &mut test::Bencher)
+{
+    let mut a = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
+    a.swap_axes(0, 1);
+    let mut b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
+    b.swap_axes(0, 1);
+    bench.iter(|| {
+        a += &b;
+    });
+}
+
+#[bench]
+fn add_2d_zip_both_transposed(bench: &mut test::Bencher)
+{
+    let mut a = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
+    a.swap_axes(0, 1);
+    let mut b = Array::<i32, _>::zeros((ADD2DSZ, ADD2DSZ));
+    b.swap_axes(0, 1);
     bench.iter(|| {
         Zip::from(&mut a).and(&b).apply(|a, &b| *a += b);
     });

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1242,7 +1242,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///               [false, true]])
     /// );
     /// ```
-    pub fn map<'a, B, F>(&'a self, mut f: F) -> Array<B, D>
+    pub fn map<'a, B, F>(&'a self, f: F) -> Array<B, D>
         where F: FnMut(&'a A) -> B,
               A: 'a,
     {

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -302,7 +302,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// Return a mutable reference to the element at `index`.
     ///
     /// **Note:** Only unchecked for non-debug builds of ndarray.<br>
-    /// **Note:** The array must be uniquely held when mutating it.
+    /// **Note:** (For `RcArray`) The array must be uniquely held when mutating it.
     #[inline]
     pub unsafe fn uget_mut<I>(&mut self, index: I) -> &mut A
         where S: DataMut,

--- a/src/layout/layoutfmt.rs
+++ b/src/layout/layoutfmt.rs
@@ -9,6 +9,7 @@
 
 use itertools::Itertools;
 use super::Layout;
+use super::LayoutPriv;
 
 const LAYOUT_NAMES: &'static [&'static str] = &["C", "F"];
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,0 +1,60 @@
+
+mod layoutfmt;
+
+// public but users don't interact with it
+#[doc(hidden)]
+/// Memory layout description
+#[derive(Copy, Clone)]
+pub struct Layout(u32);
+
+pub trait LayoutPriv : Sized {
+    fn new(x: u32) -> Self;
+    fn and(self, flag: Self) -> Self;
+    fn is(self, flag: u32) -> bool;
+    fn flag(self) -> u32;
+}
+
+impl LayoutPriv for Layout {
+    #[inline(always)]
+    fn new(x: u32) -> Self { Layout(x) }
+
+    #[inline(always)]
+    fn is(self, flag: u32) -> bool {
+        self.0 & flag != 0
+    }
+    #[inline(always)]
+    fn and(self, flag: Layout) -> Layout {
+        Layout(self.0 & flag.0)
+    }
+
+    #[inline(always)]
+    fn flag(self) -> u32 {
+        self.0
+    }
+}
+
+impl Layout {
+    #[doc(hidden)]
+    #[inline(always)]
+    pub fn one_dimensional() -> Layout {
+        Layout(CORDER | FORDER)
+    }
+    #[doc(hidden)]
+    #[inline(always)]
+    pub fn c() -> Layout {
+        Layout(CORDER)
+    }
+    #[doc(hidden)]
+    #[inline(always)]
+    pub fn f() -> Layout {
+        Layout(FORDER)
+    }
+    #[inline(always)]
+    #[doc(hidden)]
+    pub fn none() -> Layout {
+        Layout(0)
+    }
+}
+
+pub const CORDER: u32 = 1 << 0;
+pub const FORDER: u32 = 1 << 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@ mod dimension;
 mod free_functions;
 pub use free_functions::*;
 
+mod layout;
 mod indexes;
 mod iterators;
 mod linalg_traits;
@@ -160,9 +161,10 @@ pub use zip::{
     Zip,
     NdProducer,
     IntoNdProducer,
-    Layout,
     FoldWhile,
 };
+
+pub use layout::Layout;
 
 /// Implementation's prelude. Common types used everywhere.
 mod imp_prelude {

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -60,7 +60,7 @@ impl<S, D> LayoutImpl for ArrayBase<S, D>
             } else {
                 CORDER
             }
-        } else if self.as_slice_memory_order().is_some() {
+        } else if self.ndim() > 1 && self.t().is_standard_layout() {
             FORDER
         } else {
             0

--- a/src/zip/mod.rs
+++ b/src/zip/mod.rs
@@ -6,12 +6,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod layoutfmt;
 mod zipmacro;
 
 use imp_prelude::*;
 use IntoDimension;
 use NdIndex;
+use Layout;
+
+use layout::{CORDER, FORDER};
+use layout::LayoutPriv;
 
 /// Return if the expression is a break value.
 macro_rules! fold_while {
@@ -23,50 +26,6 @@ macro_rules! fold_while {
     }
 }
 
-// public but users don't interact with it
-#[doc(hidden)]
-/// Memory layout description
-#[derive(Copy, Clone)]
-pub struct Layout(u32);
-
-impl Layout {
-    #[doc(hidden)]
-    #[inline(always)]
-    pub fn one_dimensional() -> Layout {
-        Layout(CORDER | FORDER)
-    }
-    #[doc(hidden)]
-    #[inline(always)]
-    pub fn c() -> Layout {
-        Layout(CORDER)
-    }
-    #[doc(hidden)]
-    #[inline(always)]
-    pub fn f() -> Layout {
-        Layout(FORDER)
-    }
-    #[inline(always)]
-    #[doc(hidden)]
-    pub fn none() -> Layout {
-        Layout(0)
-    }
-    #[inline(always)]
-    fn is(self, flag: u32) -> bool {
-        self.0 & flag != 0
-    }
-    #[inline(always)]
-    fn and(self, flag: Layout) -> Layout {
-        Layout(self.0 & flag.0)
-    }
-
-    #[inline(always)]
-    fn flag(self) -> u32 {
-        self.0
-    }
-}
-
-const CORDER: u32 = 1 << 0;
-const FORDER: u32 = 1 << 1;
 
 //use ndarray::Axis;
 
@@ -95,7 +54,7 @@ impl<S, D> LayoutImpl for ArrayBase<S, D>
           D: Dimension,
 {
     fn layout_impl(&self) -> Layout {
-        Layout(if self.is_standard_layout() {
+        Layout::new(if self.is_standard_layout() {
             if self.ndim() <= 1 {
                 FORDER | CORDER
             } else {


### PR DESCRIPTION
Fixes #296 

Like the test case shows, there was a bug:

```rust
// Test that Zip handles memory layout correctly for
// Zip::from(A).and(B)
// where A is F-contiguous and B contiguous but neither F nor C contiguous.
```

The case of B contiguous but neither F nor C contiguous can only appear if B has at least 3 dimensions and has axes manually swapped.