### PR TITLE
Add general matrix-vector multiplication

### DIFF
--- a/benches/gemv.rs
+++ b/benches/gemv.rs
@@ -1,0 +1,42 @@
+#![feature(test)]
+
+extern crate test;
+use test::Bencher;
+
+extern crate ndarray;
+use ndarray::prelude::*;
+
+use ndarray::linalg::general_mat_vec_mul;
+
+#[bench]
+fn gemv_64_64c(bench: &mut Bencher) {
+    let a = Array::zeros((64, 64));
+    let (m, n) = a.dim();
+    let x = Array::zeros(n);
+    let mut y = Array::zeros(m);
+    bench.iter(|| {
+        general_mat_vec_mul(1.0, &a, &x, 1.0, &mut y);
+    });
+}
+
+#[bench]
+fn gemv_64_64f(bench: &mut Bencher) {
+    let a = Array::zeros((64, 64).f());
+    let (m, n) = a.dim();
+    let x = Array::zeros(n);
+    let mut y = Array::zeros(m);
+    bench.iter(|| {
+        general_mat_vec_mul(1.0, &a, &x, 1.0, &mut y);
+    });
+}
+
+#[bench]
+fn gemv_64_32(bench: &mut Bencher) {
+    let a = Array::zeros((64, 32));
+    let (m, n) = a.dim();
+    let x = Array::zeros(n);
+    let mut y = Array::zeros(m);
+    bench.iter(|| {
+        general_mat_vec_mul(1.0, &a, &x, 1.0, &mut y);
+    });
+}

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -365,6 +365,7 @@ fn mat_mul_impl<A>(alpha: A,
                     // adjust strides, these may [1, 1] for column matrices
                     let lhs_stride = cmp::max(lhs_.strides()[0] as blas_index, k as blas_index);
                     let rhs_stride = cmp::max(rhs_.strides()[0] as blas_index, n as blas_index);
+                    let c_stride = cmp::max(c_.strides()[0] as blas_index, n as blas_index);
 
                     // gemm is C ← αA^Op B^Op + βC
                     // Where Op is notrans/trans/conjtrans
@@ -383,7 +384,7 @@ fn mat_mul_impl<A>(alpha: A,
                         rhs_stride, // ldb
                         cast_as(&beta),         // beta
                         c_.ptr as *mut _,       // c
-                        c_.strides()[0] as blas_index, // ldc
+                        c_stride, // ldc
                     );
                     }
                 return;

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -47,7 +47,9 @@ impl<A, S> ArrayBase<S, Ix1>
     /// The dot product is a sum of the elementwise products (no conjugation
     /// of complex operands, and thus not their inner product).
     ///
-    /// **Panics** if the arrays are not of the same length.
+    /// **Panics** if the arrays are not of the same length.<br>
+    /// *Note:* If enabled, uses blas `dot` for elements of `f32, f64` when memory
+    /// layout allows.
     pub fn dot<S2>(&self, rhs: &ArrayBase<S2, Ix1>) -> A
         where S2: Data<Elem=A>,
               A: LinalgScalar,
@@ -166,7 +168,10 @@ impl<A, S> ArrayBase<S, Ix2>
     ///
     /// Return a result array with shape *M* × *K*.
     ///
-    /// **Panics** if shapes are incompatible.
+    /// **Panics** if shapes are incompatible.<br>
+    /// *Note:* If enabled, uses blas `gemv/gemm` for elements of `f32, f64`
+    /// when memory layout allows. The default matrixmultiply backend
+    /// is otherwise used for `f32, f64` for all memory layouts.
     ///
     /// ```
     /// use ndarray::arr2;
@@ -466,7 +471,10 @@ fn mat_mul_general<A>(alpha: A,
 /// The array shapes must agree in the way that
 /// if `a` is *M* × *N*, then `b` is *N* × *K* and `c` is *M* × *K*.
 ///
-/// ***Panics*** if array shapes are not compatible
+/// ***Panics*** if array shapes are not compatible<br>
+/// *Note:* If enabled, uses blas `gemm` for elements of `f32, f64` when memory
+/// layout allows.  The default matrixmultiply backend is otherwise used for
+/// `f32, f64` for all memory layouts.
 pub fn general_mat_mul<A, S1, S2, S3>(alpha: A,
                                       a: &ArrayBase<S1, Ix2>,
                                       b: &ArrayBase<S2, Ix2>,
@@ -493,7 +501,9 @@ pub fn general_mat_mul<A, S1, S2, S3>(alpha: A,
 /// where A is a *M* × *N* matrix and x is a *N* column vector and y a *M*
 /// column vector (one dimensional arrays).
 ///
-/// ***Panics*** if array shapes are not compatible
+/// ***Panics*** if array shapes are not compatible<br>
+/// *Note:* If enabled, uses blas `gemv` for elements of `f32, f64` when memory
+/// layout allows.
 pub fn general_mat_vec_mul<A, S1, S2, S3>(alpha: A,
                                           a: &ArrayBase<S1, Ix2>,
                                           x: &ArrayBase<S2, Ix1>,

--- a/src/linalg/impl_linalg.rs
+++ b/src/linalg/impl_linalg.rs
@@ -6,8 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use itertools::free::enumerate;
-
 use imp_prelude::*;
 use numeric_util;
 
@@ -260,19 +258,10 @@ impl<A, S, S2> Dot<ArrayBase<S2, Ix1>> for ArrayBase<S, Ix2>
         }
 
         // Avoid initializing the memory in vec -- set it during iteration
-        let mut res_elems = Vec::<A>::with_capacity(m as usize);
         unsafe {
-            res_elems.set_len(m as usize);
-        }
-        for (i, rr) in enumerate(&mut res_elems) {
-            unsafe {
-                *rr = (0..a).fold(A::zero(),
-                    move |s, k| s + *self.uget(Ix2(i, k)) * *rhs.uget(k)
-                );
-            }
-        }
-        unsafe {
-            ArrayBase::from_shape_vec_unchecked(m, res_elems)
+            let mut c = Array::uninitialized(m);
+            general_mat_vec_mul(A::one(), self, rhs, A::zero(), &mut c);
+            c
         }
     }
 }

--- a/src/linalg/mod.rs
+++ b/src/linalg/mod.rs
@@ -11,5 +11,6 @@
 
 pub use self::impl_linalg::Dot;
 pub use self::impl_linalg::general_mat_mul;
+pub use self::impl_linalg::general_mat_vec_mul;
 
 mod impl_linalg;

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -598,6 +598,20 @@ fn gen_mat_mul() {
     }
 }
 
+
+// Test y = A x where A is f-order
+#[test]
+fn gemm_64_1_f() {
+    let a = range_mat64(64, 64).reversed_axes();
+    let (m, n) = a.dim();
+    // m x n  times n x 1  == m x 1
+    let x = range_mat64(n, 1);
+    let mut y = range_mat64(m, 1);
+    let answer = reference_mat_mul(&a, &x) + &y;
+    general_mat_mul(1.0, &a, &x, 1.0, &mut y);
+    assert_close(y.view(), answer.view());
+}
+
 #[test]
 fn gen_mat_mul_i32() {
     let alpha = -1;


### PR DESCRIPTION
- Add general matrix-vector multiplication “gemv” including BLAS bindings.
- The existing gemv `A.dot(&x)` uses the general function, which means that it
  too gains the unrolled floating point loop, improving performance for f32, f64.

Also fix a bug in BLAS bindings for gemm with column matrices (dimension n × 1).

Benchmarks show (not all included) that OpenBLAS doesn't redirect to gemv for column matrices in gemm either, so we don't. We let the user know their data and pick the corect out of gemm and gemv up front. (Both work with columns, but gemm will be slower).

Fixes #289 