### PR TITLE
parallel: Fix .collect() for the element par iters

### DIFF
--- a/parallel/src/par.rs
+++ b/parallel/src/par.rs
@@ -162,7 +162,7 @@ macro_rules! par_iter_view_wrapper {
         }
 
         fn opt_len(&mut self) -> Option<usize> {
-            Some(self.iter.len())
+            None
         }
     }
 

--- a/parallel/tests/rayon.rs
+++ b/parallel/tests/rayon.rs
@@ -40,3 +40,13 @@ fn test_regular_iter() {
     println!("{:?}", a.slice(s![..10, ..5]));
     assert_eq!(s, a.scalar_sum());
 }
+
+#[test]
+fn test_regular_iter_collect() {
+    let mut a = Array2::<f64>::zeros((M, N));
+    for (i, mut v) in a.axis_iter_mut(Axis(0)).enumerate() {
+        v.fill(i as _);
+    }
+    let v = a.view().into_par_iter().map(|&x| x).collect::<Vec<_>>();
+    assert_eq!(v.len(), a.len());
+}


### PR DESCRIPTION
- They must not define opt_len to return Some (reserved for indexed iterators).
- Added test that shows problem and verifies the fix