### PR TITLE
Fix two bugs with `Array::from_shape_fn`

### DIFF
--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -192,6 +192,27 @@ pub trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
     }
 
     #[doc(hidden)]
+    /// Iteration -- Use self as size, and create the next index after `index`
+    /// Return false if iteration is done
+    ///
+    /// Next in f-order
+    #[inline]
+    fn next_for_f(&self, index: &mut Self) -> bool {
+        let mut end_iteration = true;
+        for (&dim, ix) in zip(self.slice(), index.slice_mut()) {
+            *ix += 1;
+            if *ix == dim {
+                *ix = 0;
+            } else {
+                end_iteration = false;
+                break;
+            }
+        }
+        !end_iteration
+    }
+
+
+    #[doc(hidden)]
     /// Return stride offset for index.
     fn stride_offset(index: &Self, strides: &Self) -> isize {
         let mut offset = 0;

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -202,6 +202,7 @@ impl<S, A, D> ArrayBase<S, D>
               F: FnMut(D::Pattern) -> A,
     {
         let shape = shape.into_shape();
+        let _ = size_checked_unwrap!(shape.dim);
         if shape.is_c {
             let v = to_vec_mapped(indices(shape.dim.clone()).into_iter(), f);
             unsafe { Self::from_shape_vec_unchecked(shape, v) }

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -18,6 +18,7 @@ use dimension;
 use linspace;
 use error::{self, ShapeError, ErrorKind};
 use indices;
+use indexes;
 use iterators::{to_vec, to_vec_mapped};
 
 /// # Constructor Methods for Owned Arrays
@@ -201,8 +202,14 @@ impl<S, A, D> ArrayBase<S, D>
               F: FnMut(D::Pattern) -> A,
     {
         let shape = shape.into_shape();
-        let v = to_vec_mapped(indices(shape.dim.clone()).into_iter(), f);
-        unsafe { Self::from_shape_vec_unchecked(shape, v) }
+        if shape.is_c {
+            let v = to_vec_mapped(indices(shape.dim.clone()).into_iter(), f);
+            unsafe { Self::from_shape_vec_unchecked(shape, v) }
+        } else {
+            let dim = shape.dim.clone();
+            let v = to_vec_mapped(indexes::indices_iter_f(dim).into_iter(), f);
+            unsafe { Self::from_shape_vec_unchecked(shape, v) }
+        }
     }
 
     /// Create an array with the given shape from a vector. (No cloning of

--- a/src/impl_constructors.rs
+++ b/src/impl_constructors.rs
@@ -192,7 +192,8 @@ impl<S, A, D> ArrayBase<S, D>
 
     /// Create an array with values created by the function `f`.
     ///
-    /// The elements are visited in arbitirary order.
+    /// `f` is called with the index of the element to create; the elements are
+    /// visited in arbitirary order.
     ///
     /// **Panics** if the number of elements in `shape` would overflow usize.
     pub fn from_shape_fn<Sh, F>(shape: Sh, f: F) -> Self

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -1178,6 +1178,7 @@ pub unsafe trait TrustedIterator { }
 use std;
 use linspace::Linspace;
 use iter::IndicesIter;
+use indexes::IndicesIterF;
 
 unsafe impl<F> TrustedIterator for Linspace<F> { }
 unsafe impl<'a, A, D> TrustedIterator for Iter<'a, A, D> { }
@@ -1186,6 +1187,7 @@ unsafe impl<I, F> TrustedIterator for std::iter::Map<I, F>
 unsafe impl<'a, A> TrustedIterator for slice::Iter<'a, A> { }
 unsafe impl TrustedIterator for ::std::ops::Range<usize> { }
 unsafe impl<D> TrustedIterator for IndicesIter<D> where D: Dimension { }
+unsafe impl<D> TrustedIterator for IndicesIterF<D> where D: Dimension { }
 
 
 /// Like Iterator::collect, but only for trusted length iterators

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -1186,6 +1186,7 @@ unsafe impl<I, F> TrustedIterator for std::iter::Map<I, F>
     where I: TrustedIterator { }
 unsafe impl<'a, A> TrustedIterator for slice::Iter<'a, A> { }
 unsafe impl TrustedIterator for ::std::ops::Range<usize> { }
+// FIXME: These indices iter are dubious -- size needs to be checked up front.
 unsafe impl<D> TrustedIterator for IndicesIter<D> where D: Dimension { }
 unsafe impl<D> TrustedIterator for IndicesIterF<D> where D: Dimension { }
 

--- a/tests/array-construct.rs
+++ b/tests/array-construct.rs
@@ -44,6 +44,14 @@ fn test_uninit() {
 }
 
 #[test]
+fn test_from_fn_c1() {
+    let a = Array::from_shape_fn(28, |i| i);
+    for (i, elt) in a.indexed_iter() {
+        assert_eq!(i, *elt);
+    }
+}
+
+#[test]
 fn test_from_fn_c() {
     let a = Array::from_shape_fn((4, 7), |i| i);
     for (i, elt) in a.indexed_iter() {
@@ -52,8 +60,32 @@ fn test_from_fn_c() {
 }
 
 #[test]
+fn test_from_fn_c3() {
+    let a = Array::from_shape_fn((4, 3, 7), |i| i);
+    for (i, elt) in a.indexed_iter() {
+        assert_eq!(i, *elt);
+    }
+}
+
+#[test]
+fn test_from_fn_f1() {
+    let a = Array::from_shape_fn(28.f(), |i| i);
+    for (i, elt) in a.indexed_iter() {
+        assert_eq!(i, *elt);
+    }
+}
+
+#[test]
 fn test_from_fn_f() {
     let a = Array::from_shape_fn((4, 7).f(), |i| i);
+    for (i, elt) in a.indexed_iter() {
+        assert_eq!(i, *elt);
+    }
+}
+
+#[test]
+fn test_from_fn_f3() {
+    let a = Array::from_shape_fn((4, 2, 7).f(), |i| i);
     for (i, elt) in a.indexed_iter() {
         assert_eq!(i, *elt);
     }

--- a/tests/array-construct.rs
+++ b/tests/array-construct.rs
@@ -123,6 +123,12 @@ fn deny_wraparound_default() {
 
 #[should_panic]
 #[test]
+fn deny_wraparound_from_shape_fn() {
+    let _five_large = Array::<f32, _>::from_shape_fn((3, 7, 29, 36760123, 823996703), |_| 0.);
+}
+
+#[should_panic]
+#[test]
 fn deny_wraparound_uninit() {
     unsafe {
         let _five_large = Array::<f32, _>::uninitialized((3, 7, 29, 36760123, 823996703));

--- a/tests/array-construct.rs
+++ b/tests/array-construct.rs
@@ -44,6 +44,22 @@ fn test_uninit() {
 }
 
 #[test]
+fn test_from_fn_c() {
+    let a = Array::from_shape_fn((4, 7), |i| i);
+    for (i, elt) in a.indexed_iter() {
+        assert_eq!(i, *elt);
+    }
+}
+
+#[test]
+fn test_from_fn_f() {
+    let a = Array::from_shape_fn((4, 7).f(), |i| i);
+    for (i, elt) in a.indexed_iter() {
+        assert_eq!(i, *elt);
+    }
+}
+
+#[test]
 fn deny_wraparound_from_vec() {
     let five = vec![0; 5];
     let five_large = Array::from_shape_vec((3, 7, 29, 36760123, 823996703), five.clone());


### PR DESCRIPTION
- The indices did not map correctly to element position for f-order shapes
- from_shape_fn did not correctly check the size for overflow