### PR TITLE
Add parallel (+ par indexed) version for azip macro

### DIFF
--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -18,4 +18,4 @@ ndarray = { version = "0.9.0", path = "../" }
 
 [dev-dependencies]
 num_cpus = "1.2"
-
+itertools = "0.6"

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -130,3 +130,4 @@ mod par;
 mod ext_traits;
 mod into_traits;
 mod into_impls;
+mod zipmacro;

--- a/parallel/src/zipmacro.rs
+++ b/parallel/src/zipmacro.rs
@@ -1,0 +1,105 @@
+// Copyright 2017 bluss and ndarray developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_export]
+/// Parallel version of the `azip!` macro.
+///
+/// See the `azip!` documentation for more details.
+///
+/// This example:
+///
+/// ```rust,ignore
+/// par_azip!(mut a, b, c in { *a = b + c })
+/// ```
+///
+/// Is equivalent to:
+///
+/// ```rust,ignore
+/// Zip::from(&mut a).and(&b).and(&c).par_apply(|a, &b, &c| {
+///     *a = b + c;
+/// });
+/// ```
+///
+/// **Panics** if any of the arrays are not of the same shape.
+///
+/// ## Examples
+///
+/// ```rust
+/// extern crate ndarray;
+/// #[macro_use(par_azip)]
+/// extern crate ndarray_parallel;
+///
+/// use ndarray::Array2;
+///
+/// type M = Array2<f32>;
+///
+/// fn main() {
+///     let mut a = M::zeros((16, 16));
+///     let b = M::from_elem(a.dim(), 1.);
+///     let c = M::from_elem(a.dim(), 2.);
+///
+///     // Compute a simple ternary operation:
+///     // elementwise addition of b and c, stored in a
+///
+///     par_azip!(mut a, b, c in { *a = b + c });
+///
+///     assert_eq!(a, &b + &c);
+/// }
+/// ```
+macro_rules! par_azip {
+    // Final Rule (index)
+    (@parse [index => $a:expr, $($aa:expr,)*] [$($p:pat,)+] in { $($t:tt)* }) => {
+        $crate::ndarray::Zip::indexed($a)
+            $(
+                .and($aa)
+            )*
+            .par_apply(|$($p),+| {
+                $($t)*
+            })
+    };
+    // Final Rule (no index)
+    (@parse [$a:expr, $($aa:expr,)*] [$($p:pat,)+] in { $($t:tt)* }) => {
+        $crate::ndarray::Zip::from($a)
+            $(
+                .and($aa)
+            )*
+            .par_apply(|$($p),+| {
+                $($t)*
+            })
+    };
+    // parsing stack: [expressions] [patterns] (one per operand)
+    // index uses empty [] -- must be first
+    (@parse [] [] index $i:pat, $($t:tt)*) => {
+        par_azip!(@parse [index =>] [$i,] $($t)*);
+    };
+    (@parse [$($exprs:tt)*] [$($pats:tt)*] mut $x:ident ($e:expr) $($t:tt)*) => {
+        par_azip!(@parse [$($exprs)* $e,] [$($pats)* mut $x,] $($t)*);
+    };
+    (@parse [$($exprs:tt)*] [$($pats:tt)*] mut $x:ident $($t:tt)*) => {
+        par_azip!(@parse [$($exprs)* &mut $x,] [$($pats)* mut $x,] $($t)*);
+    };
+    (@parse [$($exprs:tt)*] [$($pats:tt)*] , $($t:tt)*) => {
+        par_azip!(@parse [$($exprs)*] [$($pats)*] $($t)*);
+    };
+    (@parse [$($exprs:tt)*] [$($pats:tt)*] ref $x:ident ($e:expr) $($t:tt)*) => {
+        par_azip!(@parse [$($exprs)* $e,] [$($pats)* $x,] $($t)*);
+    };
+    (@parse [$($exprs:tt)*] [$($pats:tt)*] ref $x:ident $($t:tt)*) => {
+        par_azip!(@parse [$($exprs)* &$x,] [$($pats)* $x,] $($t)*);
+    };
+    (@parse [$($exprs:tt)*] [$($pats:tt)*] $x:ident ($e:expr) $($t:tt)*) => {
+        par_azip!(@parse [$($exprs)* $e,] [$($pats)* &$x,] $($t)*);
+    };
+    (@parse [$($exprs:tt)*] [$($pats:tt)*] $x:ident $($t:tt)*) => {
+        par_azip!(@parse [$($exprs)* &$x,] [$($pats)* &$x,] $($t)*);
+    };
+    (@parse [$($exprs:tt)*] [$($pats:tt)*] $($t:tt)*) => { };
+    ($($t:tt)*) => {
+        par_azip!(@parse [] [] $($t)*);
+    }
+}

--- a/parallel/tests/azip.rs
+++ b/parallel/tests/azip.rs
@@ -1,0 +1,69 @@
+
+extern crate ndarray;
+#[macro_use]
+extern crate ndarray_parallel;
+extern crate itertools;
+
+use ndarray::prelude::*;
+use ndarray_parallel::prelude::*;
+
+use itertools::{assert_equal, cloned, enumerate};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[test]
+fn test_par_azip1() {
+    let mut a = Array::zeros(62);
+    let b = Array::from_elem(62, 42);
+    par_azip!(mut a in { *a = 42 });
+    assert_eq!(a, b);
+}
+
+#[test]
+fn test_par_azip2() {
+    let mut a = Array::zeros((5, 7));
+    let b = Array::from_shape_fn(a.dim(), |(i, j)| 1. / (i + 2*j) as f32);
+    par_azip!(mut a, b in { *a = b; });
+    assert_eq!(a, b);
+}
+
+#[test]
+fn test_par_azip3() {
+    let mut a = [0.; 32];
+    let mut b = [0.; 32];
+    let mut c = [0.; 32];
+    for (i, elt) in enumerate(&mut b) {
+        *elt = i as f32;
+    }
+
+    par_azip!(mut a (&mut a[..]), b (&b[..]), mut c (&mut c[..]) in {
+        *a += b / 10.;
+        *c = a.sin();
+    });
+    let res = Array::linspace(0., 3.1, 32).mapv_into(f32::sin);
+    assert!(res.all_close(&ArrayView::from(&c), 1e-4));
+}
+
+#[should_panic]
+#[test]
+fn test_zip_dim_mismatch_1() {
+    let mut a = Array::zeros((5, 7));
+    let mut d = a.raw_dim();
+    d[0] += 1;
+    let b = Array::from_shape_fn(d, |(i, j)| 1. / (i + 2*j) as f32);
+    par_azip!(mut a, b in { *a = b; });
+}
+
+#[test]
+fn test_indices_1() {
+    let mut a1 = Array::default(12);
+    for (i, elt) in a1.indexed_iter_mut() {
+        *elt = i;
+    }
+
+    let mut count = AtomicUsize::new(0);
+    par_azip!(index i, elt (&a1) in {
+        count.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(elt, i);
+    });
+    assert_eq!(count.load(Ordering::SeqCst), a1.len());
+}


### PR DESCRIPTION
Introduce the `par_azip!` and `par_azip_indexed!` macros to the parallel crate similar to the existing `azip!` macro.

Implementation details:
- `par_azip` is basically `azip` but calling `par_apply` instead of `apply`
- `par_azip_indexed` using additional states for parsing the `index $tt` part at the end
- Reexporting `Zip` in the library to make use of `$crate::Zip` inside the macro (I'm not aware of a better way).

Fixes #326 