### PR TITLE
ENH: Serde 1.0 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ blas-sys = { version = "0.6.5", optional = true, default-features = false }
 matrixmultiply = { version = "0.1.13" }
 
 [dependencies.serde]
-version = "0.9"
+version = "1.0"
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ blas-sys = { version = "0.6.5", optional = true, default-features = false }
 matrixmultiply = { version = "0.1.13" }
 
 [dependencies.serde]
+# Use via the `serde-1` crate feature!
 version = "1.0"
 optional = true
 
@@ -50,14 +51,19 @@ optional = true
 defmac = "0.1"
 
 [features]
+# Enable blas usage
+# See README for more instructions
 blas = ["blas-sys"]
+
+# Serde 1.0
+serde-1 = ["serde"]
 
 # These features are used for testing
 blas-openblas-sys = ["blas"]
 test = ["blas-openblas-sys"]
 
 # This feature is used for docs
-docs = ["rustc-serialize", "serde"]
+docs = ["rustc-serialize", "serde-1"]
 
 [profile.release]
 [profile.bench]

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ your `Cargo.toml`.
   - Optional, compatible with Rust stable
   - Enables serialization support for rustc-serialize 0.3
 
-- ``serde``
+- ``serde-1``
 
   - Optional, compatible with Rust stable
   - Enables serialization support for serde 1.0

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ your `Cargo.toml`.
 - ``serde``
 
   - Optional, compatible with Rust stable
-  - Enables serialization support for serde 0.9
+  - Enables serialization support for serde 1.0
 
 - ``blas``
 

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 test = false
 
 [dependencies]
-ndarray = { version = "*", path = "../", features = ["serde", "rustc-serialize"] }
+ndarray = { version = "*", path = "../", features = ["serde-1", "rustc-serialize"] }
 
 [dev-dependencies.rustc-serialize]
 version = "0.3.21"

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -14,11 +14,11 @@ ndarray = { version = "*", path = "../", features = ["serde", "rustc-serialize"]
 version = "0.3.21"
 
 [dev-dependencies.serde]
-version = "0.9"
+version = "1.0"
 
 [dev-dependencies.serde_json]
-version = "0.9"
+version = "1.0"
 
 [dev-dependencies.rmp-serde]
-version = "=0.12.0"
+version = "0.13.1"
 

--- a/src/array_serde.rs
+++ b/src/array_serde.rs
@@ -31,7 +31,7 @@ pub fn verify_version<E>(v: u8) -> Result<(), E>
     Ok(())
 }
 
-/// **Requires crate feature `"serde"`**
+/// **Requires crate feature `"serde-1"`**
 impl<I> Serialize for Dim<I>
     where I: Serialize,
 {
@@ -42,7 +42,7 @@ impl<I> Serialize for Dim<I>
     }
 }
 
-/// **Requires crate feature `"serde"`**
+/// **Requires crate feature `"serde-1"`**
 impl<'de, I> Deserialize<'de> for Dim<I>
     where I: Deserialize<'de>,
 {
@@ -53,7 +53,7 @@ impl<'de, I> Deserialize<'de> for Dim<I>
     }
 }
 
-/// **Requires crate feature `"serde"`**
+/// **Requires crate feature `"serde-1"`**
 impl<A, D, S> Serialize for ArrayBase<S, D>
     where A: Serialize,
           D: Dimension + Serialize,
@@ -109,7 +109,7 @@ impl<S, Di> ArrayVisitor<S, Di> {
 
 static ARRAY_FIELDS: &'static [&'static str] = &["v", "dim", "data"];
 
-/// **Requires crate feature `"serde"`**
+/// **Requires crate feature `"serde-1"`**
 impl<'de, A, Di, S> Deserialize<'de> for ArrayBase<S, Di>
     where A: Deserialize<'de>,
           Di: Deserialize<'de> + Dimension,

--- a/src/array_serde.rs
+++ b/src/array_serde.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
-use serde::de::{self, Visitor, SeqVisitor, MapVisitor};
+use serde::de::{self, Visitor, SeqAccess, MapAccess};
 use serde::ser::{SerializeSeq, SerializeStruct};
 
 use std::fmt;
@@ -43,11 +43,11 @@ impl<I> Serialize for Dim<I>
 }
 
 /// **Requires crate feature `"serde"`**
-impl<I> Deserialize for Dim<I>
-    where I: Deserialize,
+impl<'de, I> Deserialize<'de> for Dim<I>
+    where I: Deserialize<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
         I::deserialize(deserializer).map(Dim::new)
     }
@@ -110,25 +110,25 @@ impl<S, Di> ArrayVisitor<S, Di> {
 static ARRAY_FIELDS: &'static [&'static str] = &["v", "dim", "data"];
 
 /// **Requires crate feature `"serde"`**
-impl<A, Di, S> Deserialize for ArrayBase<S, Di>
-    where A: Deserialize,
-          Di: Deserialize + Dimension,
+impl<'de, A, Di, S> Deserialize<'de> for ArrayBase<S, Di>
+    where A: Deserialize<'de>,
+          Di: Deserialize<'de> + Dimension,
           S: DataOwned<Elem = A>
 {
     fn deserialize<D>(deserializer: D) -> Result<ArrayBase<S, Di>, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
         deserializer.deserialize_struct("Array", ARRAY_FIELDS, ArrayVisitor::new())
     }
 }
 
-impl Deserialize for ArrayField {
+impl<'de> Deserialize<'de> for ArrayField {
     fn deserialize<D>(deserializer: D) -> Result<ArrayField, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
         struct ArrayFieldVisitor;
 
-        impl Visitor for ArrayFieldVisitor {
+        impl<'de> Visitor<'de> for ArrayFieldVisitor {
             type Value = ArrayField;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -147,13 +147,13 @@ impl Deserialize for ArrayField {
             }
         }
 
-        deserializer.deserialize_struct_field(ArrayFieldVisitor)
+        deserializer.deserialize_identifier(ArrayFieldVisitor)
     }
 }
 
-impl<A, Di, S> Visitor for ArrayVisitor<S,Di>
-    where A: Deserialize,
-          Di: Deserialize + Dimension,
+impl<'de, A, Di, S> Visitor<'de> for ArrayVisitor<S,Di>
+    where A: Deserialize<'de>,
+          Di: Deserialize<'de> + Dimension,
           S: DataOwned<Elem = A>
 {
     type Value = ArrayBase<S, Di>;
@@ -163,9 +163,9 @@ impl<A, Di, S> Visitor for ArrayVisitor<S,Di>
     }
 
     fn visit_seq<V>(self, mut visitor: V) -> Result<ArrayBase<S, Di>, V::Error>
-        where V: SeqVisitor
+        where V: SeqAccess<'de>,
     {
-        let v: u8 = match try!(visitor.visit()) {
+        let v: u8 = match try!(visitor.next_element()) {
             Some(value) => value,
             None => {
                 return Err(de::Error::invalid_length(0, &self));
@@ -174,14 +174,14 @@ impl<A, Di, S> Visitor for ArrayVisitor<S,Di>
 
         try!(verify_version(v));
 
-        let dim: Di = match try!(visitor.visit()) {
+        let dim: Di = match try!(visitor.next_element()) {
             Some(value) => value,
             None => {
                 return Err(de::Error::invalid_length(1, &self));
             }
         };
 
-        let data: Vec<A> = match try!(visitor.visit()) {
+        let data: Vec<A> = match try!(visitor.next_element()) {
             Some(value) => value,
             None => {
                 return Err(de::Error::invalid_length(2, &self));
@@ -196,24 +196,24 @@ impl<A, Di, S> Visitor for ArrayVisitor<S,Di>
     }
 
     fn visit_map<V>(self, mut visitor: V) -> Result<ArrayBase<S, Di>, V::Error>
-        where V: MapVisitor,
+        where V: MapAccess<'de>,
     {
         let mut v: Option<u8> = None;
         let mut data: Option<Vec<A>> = None;
         let mut dim: Option<Di> = None;
 
-        while let Some(key) = try!(visitor.visit_key()) {
+        while let Some(key) = try!(visitor.next_key()) {
             match key {
                 ArrayField::Version => {
-                    let val = try!(visitor.visit_value());
+                    let val = try!(visitor.next_value());
                     try!(verify_version(val));
                     v = Some(val);
                 },
                 ArrayField::Data => {
-                    data = Some(try!(visitor.visit_value()));
+                    data = Some(try!(visitor.next_value()));
                 },
                 ArrayField::Dim => {
-                    dim = Some(try!(visitor.visit_value()));
+                    dim = Some(try!(visitor.next_value()));
                 },
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //! - `rustc-serialize`
 //!   - Optional, compatible with Rust stable
 //!   - Enables serialization support for rustc-serialize 0.3
-//! - `serde`
+//! - `serde-1`
 //!   - Optional, compatible with Rust stable
 //!   - Enables serialization support for serde 1.0
 //! - `blas`
@@ -66,7 +66,7 @@
 //!     separately.
 //!
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde-1")]
 extern crate serde;
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize as serialize;
@@ -113,7 +113,7 @@ pub use shape_builder::{ ShapeBuilder};
 #[macro_use] mod private;
 mod aliases;
 mod arraytraits;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde-1")]
 mod array_serde;
 #[cfg(feature = "rustc-serialize")]
 mod array_serialize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //!   - Enables serialization support for rustc-serialize 0.3
 //! - `serde`
 //!   - Optional, compatible with Rust stable
-//!   - Enables serialization support for serde 0.9
+//!   - Enables serialization support for serde 1.0
 //! - `blas`
 //!   - Optional and experimental, compatible with Rust stable
 //!   - Enable transparent BLAS support for matrix multiplication.


### PR DESCRIPTION
Supersedes #319 

Crate feature for serde is now `serde-1`. We version crate features that are used for interchange with other crates.