### PR TITLE
Add support for scalar operation on bignums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,14 @@ default-features = false
 version = "0.1.32"
 default-features = false
 
+[dependencies.num-bigint]
+version = "0.1.32"
+default-features = false
+
+[dependencies.num-rational]
+version = "0.1.32"
+default-features = false
+
 [dependencies.itertools]
 version = "0.6.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,8 @@ extern crate matrixmultiply;
 extern crate itertools;
 extern crate num_traits as libnum;
 extern crate num_complex;
+extern crate num_bigint;
+extern crate num_rational;
 
 use std::iter::Zip as ZipIter;
 use std::marker::PhantomData;


### PR DESCRIPTION
Adds support for scalar operations on bignums, and also introduces more macros to avoid code duplication.

It would be better to have more generic impls for Ratio (and Complex), but that would take significantly more code, so it's left as a future extension.

Fixes #333.
