### PR TITLE
serde: Deserialize from bytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ script:
       cargo build --verbose --features "$FEATURES" &&
       cargo test --verbose --features "$FEATURES" &&
       cargo test --manifest-path=parallel/Cargo.toml --verbose &&
-      cargo test --manifest-path=serialization-tests/Cargo.toml --verbose &&
+      if [[ "$TRAVIS_RUST_VERSION" == "1.18.0" ]]; then
+        cargo test --manifest-path=serialization-tests/Cargo.toml --verbose --no-default-features
+      else
+        cargo test --manifest-path=serialization-tests/Cargo.toml --verbose
+      fi &&
       CARGO_TARGET_DIR=target/ cargo test --manifest-path=numeric-tests/Cargo.toml --verbose &&
       ([ "$BENCH" != 1 ] || cargo bench --no-run --verbose --features "$FEATURES")

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -10,6 +10,9 @@ test = false
 [dependencies]
 ndarray = { path = "../", features = ["serde-1", "rustc-serialize"] }
 
+[features]
+default = ["ron"]
+
 [dev-dependencies.rustc-serialize]
 version = "0.3.21"
 
@@ -22,5 +25,6 @@ version = "1.0"
 [dev-dependencies.rmp-serde]
 version = "0.13.1"
 
-[dev-dependencies.ron]
+[dependencies.ron]
 version = "0.1.1"
+optional = true

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -22,3 +22,5 @@ version = "1.0"
 [dev-dependencies.rmp-serde]
 version = "0.13.1"
 
+[dev-dependencies.ron]
+version = "0.1.1"

--- a/serialization-tests/tests/serialize.rs
+++ b/serialization-tests/tests/serialize.rs
@@ -8,7 +8,12 @@ extern crate serde_json;
 
 extern crate rmp_serde;
 
+extern crate ron;
+
 use serialize::json;
+
+use ron::ser::to_string as ron_serialize;
+use ron::de::from_str as ron_deserialize;
 
 use ndarray::{arr0, arr1, arr2, RcArray, RcArray1, RcArray2};
 
@@ -184,6 +189,52 @@ fn serial_many_dim_serde_msgpack()
 
         let mut deserializer = rmp_serde::Deserializer::new(&buf[..]);
         let a_de: RcArray<f32, _> = serde::Deserialize::deserialize(&mut deserializer).unwrap();
+
+        assert_eq!(a, a_de);
+    }
+}
+
+#[test]
+fn serial_many_dim_ron()
+{
+    {
+        let a = arr0::<f32>(2.72);
+
+        let a_s = ron_serialize(&a).unwrap();
+
+        let a_de: RcArray<f32, _> = ron_deserialize(&a_s).unwrap();
+
+        assert_eq!(a, a_de);
+    }
+
+    {
+        let a = arr1::<f32>(&[2.72, 1., 2.]);
+
+        let a_s = ron_serialize(&a).unwrap();
+
+        let a_de: RcArray<f32, _> = ron_deserialize(&a_s).unwrap();
+
+        assert_eq!(a, a_de);
+    }
+
+    {
+        let a = arr2(&[[3., 1., 2.2], [3.1, 4., 7.]]);
+
+        let a_s = ron_serialize(&a).unwrap();
+
+        let a_de: RcArray<f32, _> = ron_deserialize(&a_s).unwrap();
+
+        assert_eq!(a, a_de);
+    }
+
+    {
+        // Test a sliced array.
+        let mut a = RcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
+        a.islice(s![..;-1, .., .., ..2]);
+
+        let a_s = ron_serialize(&a).unwrap();
+
+        let a_de: RcArray<f32, _> = ron_deserialize(&a_s).unwrap();
 
         assert_eq!(a, a_de);
     }

--- a/serialization-tests/tests/serialize.rs
+++ b/serialization-tests/tests/serialize.rs
@@ -8,12 +8,11 @@ extern crate serde_json;
 
 extern crate rmp_serde;
 
+#[cfg(feature = "ron")]
 extern crate ron;
 
 use serialize::json;
 
-use ron::ser::to_string as ron_serialize;
-use ron::de::from_str as ron_deserialize;
 
 use ndarray::{arr0, arr1, arr2, RcArray, RcArray1, RcArray2};
 
@@ -195,8 +194,12 @@ fn serial_many_dim_serde_msgpack()
 }
 
 #[test]
+#[cfg(feature = "ron")]
 fn serial_many_dim_ron()
 {
+    use ron::ser::to_string as ron_serialize;
+    use ron::de::from_str as ron_deserialize;
+
     {
         let a = arr0::<f32>(2.72);
 

--- a/src/array_serde.rs
+++ b/src/array_serde.rs
@@ -144,6 +144,17 @@ impl<'de> Deserialize<'de> for ArrayField {
                     other => Err(de::Error::unknown_field(other, ARRAY_FIELDS)),
                 }
             }
+
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<ArrayField, E>
+                where E: de::Error
+            {
+                match value {
+                    b"v" => Ok(ArrayField::Version),
+                    b"dim" => Ok(ArrayField::Dim),
+                    b"data" => Ok(ArrayField::Data),
+                    other => Err(de::Error::unknown_field(&format!("{:?}",other), ARRAY_FIELDS)),
+                }
+            }
         }
 
         deserializer.deserialize_identifier(ArrayFieldVisitor)


### PR DESCRIPTION
I was implementing a [RON](https://github.com/ron-rs/ron) channel for some data and was unable to deserialize a ron object to an `Array3` type. Considering that there is no issue doing this through the `serde-1` option to json, messagepack, yaml etc. I figured it was an issue with the ron implementation and opened ron-rs/ron#52 on its tracker.

Turns out it was not an issue there, but an omission here.

This PR extends the `Deserialize` for `ArrayField` method to include the `visit_bytes` function, and adds tests to confirm that ron now deserializes correctly. All previous tests also pass, inferring that this addition doesn't alter any current pathways.