### PR TITLE
 Tweak bounds checked indexing code (Index, IndexMut)

### DIFF
--- a/examples/bounds_check_elim.rs
+++ b/examples/bounds_check_elim.rs
@@ -1,0 +1,103 @@
+#![crate_type="lib"]
+
+// Test cases for bounds check elimination
+
+extern crate ndarray;
+
+use ndarray::prelude::*;
+
+/*
+pub fn testslice(a: &[f64]) -> f64 {
+    let mut sum = 0.;
+    for i in 0..a.len() {
+        sum += a[i];
+    }
+    sum
+}
+
+pub fn testvec(a: &Vec<f64>) -> f64 {
+    let mut sum = 0.;
+    for i in 0..a.len() {
+        sum += a[i];
+    }
+    sum
+}
+
+pub fn testvec_as_slice(a: &Vec<f64>) -> f64 {
+    let a = a.as_slice();
+    let mut sum = 0.;
+    for i in 0..a.len() {
+        sum += a[i];
+    }
+    sum
+}
+*/
+
+#[no_mangle]
+pub fn test1d_single(a: &Array1<f64>, i: usize) -> f64 {
+    if i < a.len() { a[i] } else { 0. }
+}
+
+#[no_mangle]
+pub fn test1d_single_mut(a: &mut Array1<f64>, i: usize) -> f64 {
+    if i < a.len() { *&mut a[i] } else { 0. }
+}
+
+#[no_mangle]
+pub fn test1d_len_of(a: &Array1<f64>) -> f64 {
+    let a = &*a;
+    let mut sum = 0.;
+    for i in 0..a.len_of(Axis(0)) {
+        sum += a[i];
+    }
+    sum
+}
+
+#[no_mangle]
+pub fn test1d_range(a: &Array1<f64>) -> f64 {
+    let mut sum = 0.;
+    for i in 0..a.len() {
+        sum += a[i];
+    }
+    sum
+}
+
+#[no_mangle]
+pub fn test1d_while(a: &Array1<f64>) -> f64 {
+    let mut sum = 0.;
+    let mut i = 0;
+    while i < a.len() {
+        sum += a[i];
+        i += 1;
+    }
+    sum
+}
+
+#[no_mangle]
+pub fn test2d_ranges(a: &Array2<f64>) -> f64 {
+    let mut sum = 0.;
+    for i in 0..a.rows() {
+        for j in 0..a.cols() {
+            sum += a[[i, j]];
+        }
+    }
+    sum
+}
+
+#[no_mangle]
+pub fn test2d_whiles(a: &Array2<f64>) -> f64 {
+    let mut sum = 0.;
+    let mut i = 0;
+    while i < a.rows() {
+        let mut j = 0;
+        while j < a.cols() {
+            sum += a[[i, j]];
+            j += 1;
+        }
+        i += 1;
+    }
+    sum
+}
+
+fn main() {
+}

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -69,7 +69,10 @@ impl<S, D, I> Index<I> for ArrayBase<S, D>
     #[inline]
     fn index(&self, index: I) -> &S::Elem {
         debug_bounds_check!(self, index);
-        self.get(index).unwrap_or_else(|| array_out_of_bounds())
+        unsafe {
+            &*self.ptr.offset(index.index_checked(&self.dim, &self.strides)
+                                   .unwrap_or_else(|| array_out_of_bounds()))
+        }
     }
 }
 
@@ -84,7 +87,10 @@ impl<S, D, I> IndexMut<I> for ArrayBase<S, D>
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut S::Elem {
         debug_bounds_check!(self, index);
-        self.get_mut(index).unwrap_or_else(|| array_out_of_bounds())
+        unsafe {
+            &mut *self.as_mut_ptr().offset(index.index_checked(&self.dim, &self.strides)
+                                                .unwrap_or_else(|| array_out_of_bounds()))
+        }
     }
 }
 


### PR DESCRIPTION
Tweak bounds checked indexing code (Index, IndexMut)

Tweak bounds checked indexing code so that the compiler understands to
remove the bounds check in some simple cases. See examples in the new
example file bounds_check_elim.rs

This helps in *some* cases where a conditional or loop conditional
already do the required bounds check. Simple examples are if i < len and
while i < len loops; the range iterator loop is a worse example, it
doesn't do this as successfully! Further works is needed with that.

* Improve: test1d_single, test1d_while, test1d_range, test2d_while, test2d_range
* Need more improvement: test1d_range, test2d_range

Example input code:

```rust
pub fn test1d_single(a: &Array1<f64>, i: usize) -> f64 {
    if i < a.len() { a[i] } else { 0. }
}
```

Codegen diff:

```diff
 test1d_single:
 	.cfi_startproc
-	push	rax
-.Lcfi0:
-	.cfi_def_cfa_offset 16
 	xorps	xmm0, xmm0
 	cmp	qword ptr [rdi + 32], rsi
-	jbe	.LBB0_3
+	jbe	.LBB0_2
+	mov	rax, qword ptr [rdi + 24]
 	imul	rsi, qword ptr [rdi + 40]
-	shl	rsi, 3
-	add	rsi, qword ptr [rdi + 24]
-	je	.LBB0_4
-	movsd	xmm0, qword ptr [rsi]
-.LBB0_3:
-	pop	rax
+	movsd	xmm0, qword ptr [rax + 8*rsi]
+.LBB0_2:
 	ret
-.LBB0_4:
-	call	_ZN7ndarray11arraytraits19array_out_of_bounds17h009d4a482e88d6aaE@PLT
 .Lfunc_end0:
 	.size	test1d_single, .Lfunc_end0-test1d_single
 	.cfi_endproc
```


Full codegen diff for the bounds check elim example: https://gist.github.com/bluss/e5d9b33a1eea36894534503b0e06341a/revisions?diff=split

Note that not all examples do so well.