### PR TITLE
Fix indexing of zero-size nonzero-shape Fortran arrays

### DIFF
--- a/src/indexes.rs
+++ b/src/indexes.rs
@@ -212,7 +212,7 @@ pub fn indices_iter_f<E>(shape: E) -> IndicesIterF<E::Dim>
     let dim = shape.into_dimension();
     let zero = dim.zero_index();
     IndicesIterF {
-        has_remaining: zero != dim,
+        has_remaining: dim.size_checked() != Some(0),
         index: zero,
         dim: dim,
     }

--- a/tests/array-construct.rs
+++ b/tests/array-construct.rs
@@ -1,4 +1,5 @@
-
+#[macro_use]
+extern crate defmac;
 extern crate ndarray;
 
 use ndarray::prelude::*;
@@ -81,6 +82,21 @@ fn test_from_fn_f() {
     for (i, elt) in a.indexed_iter() {
         assert_eq!(i, *elt);
     }
+}
+
+#[test]
+fn test_from_fn_f_with_zero() {
+    defmac!(test_from_fn_f_with_zero shape => {
+        let a = Array::from_shape_fn(shape.f(), |i| i);
+        assert_eq!(a.len(), 0);
+        assert_eq!(a.shape(), &shape);
+    });
+    test_from_fn_f_with_zero!([0]);
+    test_from_fn_f_with_zero!([0, 1]);
+    test_from_fn_f_with_zero!([2, 0]);
+    test_from_fn_f_with_zero!([0, 1, 2]);
+    test_from_fn_f_with_zero!([2, 0, 1]);
+    test_from_fn_f_with_zero!([1, 2, 0]);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #361.

This is fix (and tests) for indexing a Fortran array that has zero size but has a shape with nonzero elements (e.g. shape `(1, 0)`). The bug was in `indices_iter_f()`, but this caused segfaults in `ArrayBase::from_shape_fn()`.