### PR TITLE
Add unchecked swap method (uswap)

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -341,6 +341,24 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         }
     }
 
+    /// Swap elements *unchecked* at indices `index1` and `index2`.
+    ///
+    /// Indices may be equal.
+    ///
+    /// **Note:** only unchecked for non-debug builds of ndarray.<br>
+    /// **Note:** (For `RcArray`) The array must be uniquely held.
+    pub unsafe fn uswap<I>(&mut self, index1: I, index2: I)
+        where S: DataMut,
+              I: NdIndex<D>,
+    {
+        debug_assert!(self.data.is_unique());
+        arraytraits::debug_bounds_check(self, &index1);
+        arraytraits::debug_bounds_check(self, &index2);
+        let off1 = index1.index_unchecked(&self.strides);
+        let off2 = index2.index_unchecked(&self.strides);
+        std_ptr::swap(self.ptr.offset(off1), self.ptr.offset(off2));
+    }
+
     // `get` for zero-dimensional arrays
     // panics if dimension is not zero. otherwise an element is always present.
     fn get_0d(&self) -> &A {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1154,6 +1154,21 @@ fn test_swap() {
 }
 
 #[test]
+fn test_uswap() {
+    let mut a = arr2(&[[1, 2, 3],
+                       [4, 5, 6],
+                       [7, 8, 9]]);
+    let b = a.clone();
+
+    for i in 0..a.rows() {
+        for j in i + 1..a.cols() {
+            unsafe { a.uswap((i, j), (j, i)) };
+        }
+    }
+    assert_eq!(a, b.t());
+}
+
+#[test]
 fn test_shape() {
     let data = [0, 1, 2, 3, 4, 5];
     let a = Array::from_shape_vec((1, 2, 3), data.to_vec()).unwrap();


### PR DESCRIPTION
This adds an unchecked swap method, which is necessary for performing in-place transposition of square matrices (i.e. actually moving the data around) without bounds checking. (Using `uget_mut` doesn't work for this case `::std::mem::swap(unsafe { a.uget_mut((i, j)) }, unsafe{ a.uget_mut((j, i)) })` because it would require the array to be mutably borrowed twice.)