### PR TITLE
Add support for slicing with subviews

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ sudo: required
 dist: trusty
 matrix:
   include:
-    - rust: 1.18.0
-      env:
-       - FEATURES='test'
     - rust: stable
       env:
        - FEATURES='test'

--- a/examples/axis_ops.rs
+++ b/examples/axis_ops.rs
@@ -47,7 +47,7 @@ fn main() {
     }
     a.swap_axes(0, 1);
     a.swap_axes(0, 2);
-    a.islice(s![.., ..;-1, ..]);
+    a.slice_inplace(s![.., ..;-1, ..]);
     regularize(&mut a).ok();
 
     let mut b = Array::<u8, _>::zeros((2, 3, 4));
@@ -64,6 +64,6 @@ fn main() {
     for (i, elt) in (0..).zip(&mut a) {
         *elt = i;
     }
-    a.islice(s![..;-1, ..;2, ..]);
+    a.slice_inplace(s![..;-1, ..;2, ..]);
     regularize(&mut a).ok();
 }

--- a/serialization-tests/tests/serialize.rs
+++ b/serialization-tests/tests/serialize.rs
@@ -53,7 +53,7 @@ fn serial_many_dim()
     {
         // Test a sliced array.
         let mut a = RcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
-        a.islice(s![..;-1, .., .., ..2]);
+        a.slice_inplace(s![..;-1, .., .., ..2]);
         let serial = json::encode(&a).unwrap();
         println!("Encode {:?} => {:?}", a, serial);
         let res = json::decode::<RcArray<f32, _>>(&serial);
@@ -114,7 +114,7 @@ fn serial_many_dim_serde()
     {
         // Test a sliced array.
         let mut a = RcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
-        a.islice(s![..;-1, .., .., ..2]);
+        a.slice_inplace(s![..;-1, .., .., ..2]);
         let serial = serde_json::to_string(&a).unwrap();
         println!("Encode {:?} => {:?}", a, serial);
         let res = serde_json::from_str::<RcArray<f32, _>>(&serial);
@@ -221,7 +221,7 @@ fn serial_many_dim_serde_msgpack()
     {
         // Test a sliced array.
         let mut a = RcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
-        a.islice(s![..;-1, .., .., ..2]);
+        a.slice_inplace(s![..;-1, .., .., ..2]);
 
         let mut buf = Vec::new();
         serde::Serialize::serialize(&a, &mut rmp_serde::Serializer::new(&mut buf)).ok().unwrap();
@@ -273,7 +273,7 @@ fn serial_many_dim_ron()
     {
         // Test a sliced array.
         let mut a = RcArray::linspace(0., 31., 32).reshape((2, 2, 2, 4));
-        a.islice(s![..;-1, .., .., ..2]);
+        a.slice_inplace(s![..;-1, .., .., ..2]);
 
         let a_s = ron_serialize(&a).unwrap();
 

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 
-use std::borrow::Borrow;
+use std::convert::AsRef;
 use std::fmt::Debug;
 use std::ops::{Index, IndexMut};
 use std::ops::{Add, Sub, Mul, AddAssign, SubAssign, MulAssign};
@@ -59,7 +59,7 @@ pub trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
     ///
     /// The easiest way to create a `SliceArg` is using the macro
     /// [`s![]`](macro.s!.html).
-    type SliceArg: ?Sized + Borrow<[SliceOrIndex]>;
+    type SliceArg: ?Sized + AsRef<[SliceOrIndex]>;
     /// Pattern matching friendly form of the dimension value.
     ///
     /// - For `Ix1`: `usize`,

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -252,15 +252,14 @@ pub trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
     /// Modify dimension, stride and return data pointer offset
     ///
     /// **Panics** if any stride is 0 or if any index is out of bounds.
-    fn do_slice(dim: &mut Ix, stride: &mut Ix, slice: &Si) -> isize {
+    fn do_slice(dim: &mut Ix, stride: &mut Ix, slice: Si) -> isize {
         let mut offset = 0;
         let dr = dim;
         let sr = stride;
-        let slc = *slice;
 
         let m = *dr;
         let mi = m as Ixs;
-        let Si(b1, opt_e1, s1) = slc;
+        let Si(b1, opt_e1, s1) = slice;
         let e1 = opt_e1.unwrap_or(mi);
 
         let b1 = abs_index(mi, b1);

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -42,6 +42,10 @@ pub trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
     MulAssign + for<'x> MulAssign<&'x Self> + MulAssign<usize>
 
 {
+    /// For fixed-size dimension representations (e.g. `Ix2`), this should be
+    /// `Some(ndim)`, and for variable-size dimension representations (e.g.
+    /// `IxDyn`), this should be `None`.
+    const NDIM: Option<usize>;
     /// `SliceArg` is the type which is used to specify slicing for this
     /// dimension.
     ///
@@ -428,6 +432,7 @@ macro_rules! impl_insert_axis_array(
 );
 
 impl Dimension for Dim<[Ix; 0]> {
+    const NDIM: Option<usize> = Some(0);
     type SliceArg = [SliceOrIndex; 0];
     type Pattern = ();
     type Smaller = Self;
@@ -464,6 +469,7 @@ impl Dimension for Dim<[Ix; 0]> {
 
 
 impl Dimension for Dim<[Ix; 1]> {
+    const NDIM: Option<usize> = Some(1);
     type SliceArg = [SliceOrIndex; 1];
     type Pattern = Ix;
     type Smaller = Ix0;
@@ -557,6 +563,7 @@ impl Dimension for Dim<[Ix; 1]> {
 }
 
 impl Dimension for Dim<[Ix; 2]> {
+    const NDIM: Option<usize> = Some(2);
     type SliceArg = [SliceOrIndex; 2];
     type Pattern = (Ix, Ix);
     type Smaller = Ix1;
@@ -692,6 +699,7 @@ impl Dimension for Dim<[Ix; 2]> {
 }
 
 impl Dimension for Dim<[Ix; 3]> {
+    const NDIM: Option<usize> = Some(3);
     type SliceArg = [SliceOrIndex; 3];
     type Pattern = (Ix, Ix, Ix);
     type Smaller = Ix2;
@@ -809,6 +817,7 @@ impl Dimension for Dim<[Ix; 3]> {
 macro_rules! large_dim {
     ($n:expr, $name:ident, $pattern:ty, $larger:ty, { $($insert_axis:tt)* }) => (
         impl Dimension for Dim<[Ix; $n]> {
+            const NDIM: Option<usize> = Some($n);
             type SliceArg = [SliceOrIndex; $n];
             type Pattern = $pattern;
             type Smaller = Dim<[Ix; $n - 1]>;
@@ -860,6 +869,7 @@ large_dim!(6, Ix6, (Ix, Ix, Ix, Ix, Ix, Ix), IxDyn, {
 /// and memory wasteful, but it allows an arbitrary and dynamic number of axes.
 impl Dimension for IxDyn
 {
+    const NDIM: Option<usize> = None;
     type SliceArg = [SliceOrIndex];
     type Pattern = Self;
     type Smaller = Self;

--- a/src/dimension/dimension_trait.rs
+++ b/src/dimension/dimension_trait.rs
@@ -57,8 +57,8 @@ pub trait Dimension : Clone + Eq + Debug + Send + Sync + Default +
     /// - and so on..
     /// - For `IxDyn`: `[SliceOrIndex]`
     ///
-    /// The easiest way to create a `SliceArg` is using the macro
-    /// [`s![]`](macro.s!.html).
+    /// The easiest way to create a `&SliceInfo<SliceArg, Do>` is using the
+    /// [`s![]`](macro.s!.html) macro.
     type SliceArg: ?Sized + AsRef<[SliceOrIndex]>;
     /// Pattern matching friendly form of the dimension value.
     ///

--- a/src/dimension/mod.rs
+++ b/src/dimension/mod.rs
@@ -12,7 +12,7 @@ use error::{from_kind, ErrorKind, ShapeError};
 pub use self::dim::*;
 pub use self::axis::Axis;
 pub use self::conversion::IntoDimension;
-pub use self::dimension_trait::Dimension;
+pub use self::dimension_trait::{abs_index, Dimension};
 pub use self::ndindex::NdIndex;
 pub use self::remove_axis::RemoveAxis;
 pub use self::axes::{axes_of, Axes, AxisDescription};

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -502,7 +502,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn subview(&self, axis: Axis, index: Ix) -> ArrayView<A, D::Smaller>
         where D: RemoveAxis,
     {
-        self.view().into_subview(axis, index)
+        self.view().subview_move(axis, index)
     }
 
     /// Along `axis`, select the subview `index` and return a read-write view
@@ -534,7 +534,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         where S: DataMut,
               D: RemoveAxis,
     {
-        self.view_mut().into_subview(axis, index)
+        self.view_mut().subview_move(axis, index)
     }
 
     /// Collapse dimension `axis` into length one,
@@ -550,7 +550,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// with that axis removed.
     ///
     /// See [`.subview()`](#method.subview) and [*Subviews*](#subviews) for full documentation.
-    pub fn into_subview(mut self, axis: Axis, index: Ix) -> ArrayBase<S, D::Smaller>
+    pub fn subview_move(mut self, axis: Axis, index: Ix) -> ArrayBase<S, D::Smaller>
         where D: RemoveAxis,
     {
         self.subview_inplace(axis, index);

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -261,7 +261,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         Do: Dimension,
     {
         let info: &SliceInfo<_, _> = info.borrow();
-        let indices: &[SliceOrIndex] = info.indices().borrow().borrow();
+        let indices: &D::SliceArg = info.indices().borrow();
 
         // Slice and subview in-place without changing the number of dimensions.
         self.islice(indices);
@@ -269,12 +269,11 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         // Copy the dim and strides that remain after removing the subview axes.
         let mut new_dim = Do::zero_index_with_ndim(info.out_ndim());
         let mut new_strides = Do::zero_index_with_ndim(info.out_ndim());
-        let remaining = izip!(self.dim.slice(), self.strides.slice(), indices).filter_map(
-            |(d, s, slice_or_index)| match slice_or_index {
+        let remaining = izip!(self.dim.slice(), self.strides.slice(), indices.borrow())
+            .filter_map(|(d, s, slice_or_index)| match slice_or_index {
                 &SliceOrIndex::Slice(_) => Some((d, s)),
                 &SliceOrIndex::Index(_) => None,
-            },
-        );
+            });
         for ((d, s), (new_d, new_s)) in
             remaining.zip(izip!(new_dim.slice_mut(), new_strides.slice_mut()))
         {
@@ -298,12 +297,13 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
-    pub fn islice<I>(&mut self, info: I)
+    pub fn islice<T>(&mut self, indices: T)
     where
-        I: AsRef<[SliceOrIndex]>,
+        T: Borrow<D::SliceArg>,
     {
-        assert_eq!(info.as_ref().len(), self.ndim());
-        for (axis, slice_or_index) in info.as_ref().iter().enumerate() {
+        let indices: &[SliceOrIndex] = indices.borrow().borrow();
+        assert_eq!(indices.len(), self.ndim());
+        for (axis, slice_or_index) in indices.iter().enumerate() {
             match slice_or_index {
                 &SliceOrIndex::Slice(s) => self.islice_axis(Axis(axis), &s),
                 &SliceOrIndex::Index(i) => {

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -258,16 +258,16 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         Do: Dimension,
     {
         let info: &SliceInfo<D::SliceArg, Do> = info.borrow();
-        let indices: &D::SliceArg = info.borrow();
+        let indices: &[SliceOrIndex] = info.indices().borrow();
 
         // Slice and subview in-place without changing the number of dimensions.
-        self.islice(indices);
+        self.islice(info.indices());
 
         // Copy the dim and strides that remain after removing the subview axes.
         let out_ndim = info.out_ndim();
         let mut new_dim = Do::zero_index_with_ndim(out_ndim);
         let mut new_strides = Do::zero_index_with_ndim(out_ndim);
-        izip!(self.dim.slice(), self.strides.slice(), indices.borrow())
+        izip!(self.dim.slice(), self.strides.slice(), indices)
             .filter_map(|(d, s, slice_or_index)| match slice_or_index {
                 &SliceOrIndex::Slice(_) => Some((d, s)),
                 &SliceOrIndex::Index(_) => None,

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -502,7 +502,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn subview(&self, axis: Axis, index: Ix) -> ArrayView<A, D::Smaller>
         where D: RemoveAxis,
     {
-        self.view().subview_move(axis, index)
+        self.view().into_subview(axis, index)
     }
 
     /// Along `axis`, select the subview `index` and return a read-write view
@@ -534,7 +534,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         where S: DataMut,
               D: RemoveAxis,
     {
-        self.view_mut().subview_move(axis, index)
+        self.view_mut().into_subview(axis, index)
     }
 
     /// Collapse dimension `axis` into length one,
@@ -550,7 +550,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// with that axis removed.
     ///
     /// See [`.subview()`](#method.subview) and [*Subviews*](#subviews) for full documentation.
-    pub fn subview_move(mut self, axis: Axis, index: Ix) -> ArrayBase<S, D::Smaller>
+    pub fn into_subview(mut self, axis: Axis, index: Ix) -> ArrayBase<S, D::Smaller>
         where D: RemoveAxis,
     {
         self.subview_inplace(axis, index);

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -255,9 +255,9 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         Do: Dimension,
     {
         // Slice and subview in-place without changing the number of dimensions.
-        self.islice(&info.indices);
+        self.islice(&*info);
 
-        let indices: &[SliceOrIndex] = info.indices.borrow();
+        let indices: &[SliceOrIndex] = (**info.borrow()).borrow();
 
         // Copy the dim and strides that remain after removing the subview axes.
         let out_ndim = info.out_ndim();

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -267,8 +267,9 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         self.islice(indices);
 
         // Copy the dim and strides that remain after removing the subview axes.
-        let mut new_dim = Do::zero_index_with_ndim(info.out_ndim());
-        let mut new_strides = Do::zero_index_with_ndim(info.out_ndim());
+        let out_ndim = info.out_ndim();
+        let mut new_dim = Do::zero_index_with_ndim(out_ndim);
+        let mut new_strides = Do::zero_index_with_ndim(out_ndim);
         izip!(self.dim.slice(), self.strides.slice(), indices.borrow())
             .filter_map(|(d, s, slice_or_index)| match slice_or_index {
                 &SliceOrIndex::Slice(_) => Some((d, s)),

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -217,7 +217,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// [`SliceInfo`]: struct.SliceInfo.html
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
     ///
-    /// **Panics** if an index is out of bounds or stride is zero.<br>
+    /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
     pub fn slice<Do>(&self, info: &SliceInfo<D::SliceArg, Do>) -> ArrayView<A, Do>
     where
@@ -234,7 +234,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// [`SliceInfo`]: struct.SliceInfo.html
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
     ///
-    /// **Panics** if an index is out of bounds or stride is zero.<br>
+    /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
     pub fn slice_mut<Do>(&mut self, info: &SliceInfo<D::SliceArg, Do>) -> ArrayViewMut<A, Do>
     where
@@ -252,7 +252,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// [`SliceInfo`]: struct.SliceInfo.html
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
     ///
-    /// **Panics** if an index is out of bounds or stride is zero.<br>
+    /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
     pub fn slice_move<Do>(mut self, info: &SliceInfo<D::SliceArg, Do>) -> ArrayBase<S, Do>
     where
@@ -298,7 +298,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
     ///
-    /// **Panics** if an index is out of bounds or stride is zero.<br>
+    /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
     pub fn slice_inplace(&mut self, indices: &D::SliceArg) {
         let indices: &[SliceOrIndex] = indices.as_ref();
@@ -319,7 +319,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
 
     /// Return a view of the array, sliced along the specified axis.
     ///
-    /// **Panics** if an index is out of bounds or stride is zero.<br>
+    /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// **Panics** if `axis` is out of bounds.
     pub fn slice_axis(
         &self,
@@ -335,7 +335,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
 
     /// Return a mutable view of the array, sliced along the specified axis.
     ///
-    /// **Panics** if an index is out of bounds or stride is zero.<br>
+    /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// **Panics** if `axis` is out of bounds.
     pub fn slice_axis_mut(
         &mut self,
@@ -354,7 +354,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
 
     /// Slice the array in place along the specified axis.
     ///
-    /// **Panics** if an index is out of bounds or stride is zero.<br>
+    /// **Panics** if an index is out of bounds or step size is zero.<br>
     /// **Panics** if `axis` is out of bounds.
     pub fn slice_axis_inplace(
         &mut self,

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -305,7 +305,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         assert_eq!(indices.len(), self.ndim());
         for (axis, slice_or_index) in indices.iter().enumerate() {
             match slice_or_index {
-                &SliceOrIndex::Slice(s) => self.islice_axis(Axis(axis), &s),
+                &SliceOrIndex::Slice(s) => self.islice_axis(Axis(axis), s),
                 &SliceOrIndex::Index(i) => {
                     let i_usize = abs_index(self.shape()[axis] as Ixs, i);
                     self.isubview(Axis(axis), i_usize)
@@ -318,7 +318,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
     /// **Panics** if `axis` is out of bounds.
-    pub fn slice_axis(&self, axis: Axis, indices: &Si) -> ArrayView<A, D> {
+    pub fn slice_axis(&self, axis: Axis, indices: Si) -> ArrayView<A, D> {
         let mut arr = self.view();
         arr.islice_axis(axis, indices);
         arr
@@ -328,7 +328,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
     /// **Panics** if `axis` is out of bounds.
-    pub fn slice_axis_mut(&mut self, axis: Axis, indices: &Si) -> ArrayViewMut<A, D>
+    pub fn slice_axis_mut(&mut self, axis: Axis, indices: Si) -> ArrayViewMut<A, D>
         where S: DataMut,
     {
         let mut arr = self.view_mut();
@@ -340,7 +340,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
     /// **Panics** if `axis` is out of bounds.
-    pub fn islice_axis(&mut self, axis: Axis, indices: &Si) {
+    pub fn islice_axis(&mut self, axis: Axis, indices: Si) {
         let offset = D::do_slice(
             &mut self.dim.slice_mut()[axis.index()],
             &mut self.strides.slice_mut()[axis.index()],

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -262,7 +262,6 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     {
         let info: &SliceInfo<_, _> = info.borrow();
         let indices: &[SliceOrIndex] = info.indices().borrow().borrow();
-        assert_eq!(indices.len(), self.ndim());
 
         // Slice and subview in-place without changing the number of dimensions.
         self.islice(indices);

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -324,9 +324,9 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn slice_axis(
         &self,
         axis: Axis,
-        start: isize,
-        end: Option<isize>,
-        step: isize,
+        start: Ixs,
+        end: Option<Ixs>,
+        step: Ixs,
     ) -> ArrayView<A, D> {
         let mut arr = self.view();
         arr.slice_axis_inplace(axis, start, end, step);
@@ -340,9 +340,9 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn slice_axis_mut(
         &mut self,
         axis: Axis,
-        start: isize,
-        end: Option<isize>,
-        step: isize,
+        start: Ixs,
+        end: Option<Ixs>,
+        step: Ixs,
     ) -> ArrayViewMut<A, D>
     where
         S: DataMut,
@@ -359,9 +359,9 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     pub fn slice_axis_inplace(
         &mut self,
         axis: Axis,
-        start: isize,
-        end: Option<isize>,
-        step: isize,
+        start: Ixs,
+        end: Option<Ixs>,
+        step: Ixs,
     ) {
         let offset = D::do_slice(
             &mut self.dim.slice_mut()[axis.index()],

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -209,11 +209,12 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     }
 
 
-    /// Return a sliced array.
+    /// Return a sliced view of the array.
     ///
     /// See [*Slicing*](#slicing) for full documentation.
-    /// See also [`D::SliceArg`].
+    /// See also [`SliceInfo`] and [`D::SliceArg`].
     ///
+    /// [`SliceInfo`]: struct.SliceInfo.html
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
@@ -227,8 +228,10 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
 
     /// Return a sliced read-write view of the array.
     ///
-    /// See also [`D::SliceArg`].
+    /// See [*Slicing*](#slicing) for full documentation.
+    /// See also [`SliceInfo`] and [`D::SliceArg`].
     ///
+    /// [`SliceInfo`]: struct.SliceInfo.html
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
@@ -241,10 +244,12 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         self.view_mut().slice_move(info)
     }
 
-    /// Slice the array’s view, possibly changing the number of dimensions.
+    /// Slice the array, possibly changing the number of dimensions.
     ///
-    /// See also [`D::SliceArg`].
+    /// See [*Slicing*](#slicing) for full documentation.
+    /// See also [`SliceInfo`] and [`D::SliceArg`].
     ///
+    /// [`SliceInfo`]: struct.SliceInfo.html
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
@@ -281,8 +286,14 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         }
     }
 
-    /// Slice the array’s view in place without changing the number of dimensions.
+    /// Slice the array in place without changing the number of dimensions.
     ///
+    /// Note that [`&SliceInfo`](struct.SliceInfo.html) (produced by the
+    /// [`s![]`](macro.s!.html) macro) will usually coerce into `&D::SliceArg`
+    /// automatically, but in some cases (e.g. if `D` is `IxDyn`), you may need
+    /// to call `.as_ref()`.
+    ///
+    /// See [*Slicing*](#slicing) for full documentation.
     /// See also [`D::SliceArg`].
     ///
     /// [`D::SliceArg`]: trait.Dimension.html#associatedtype.SliceArg
@@ -341,7 +352,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         arr
     }
 
-    /// Slice the array’s view in place along the specified axis.
+    /// Slice the array in place along the specified axis.
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
     /// **Panics** if `axis` is out of bounds.

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -222,7 +222,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     where
         Do: Dimension,
     {
-        self.view().slice_into(info)
+        self.view().slice_move(info)
     }
 
     /// Return a sliced read-write view of the array.
@@ -238,7 +238,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         Do: Dimension,
         S: DataMut,
     {
-        self.view_mut().slice_into(info)
+        self.view_mut().slice_move(info)
     }
 
     /// Slice the array’s view, possibly changing the number of dimensions.
@@ -249,7 +249,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     ///
     /// **Panics** if an index is out of bounds or stride is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
-    pub fn slice_into<Do>(mut self, info: &SliceInfo<D::SliceArg, Do>) -> ArrayBase<S, Do>
+    pub fn slice_move<Do>(mut self, info: &SliceInfo<D::SliceArg, Do>) -> ArrayBase<S, Do>
     where
         Do: Dimension,
     {

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::borrow::Borrow;
+use std::convert::AsRef;
 use std::cmp;
 use std::ptr as std_ptr;
 use std::slice;
@@ -257,7 +257,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         // Slice and subview in-place without changing the number of dimensions.
         self.islice(&*info);
 
-        let indices: &[SliceOrIndex] = (**info.borrow()).borrow();
+        let indices: &[SliceOrIndex] = (**info).as_ref();
 
         // Copy the dim and strides that remain after removing the subview axes.
         let out_ndim = info.out_ndim();
@@ -291,7 +291,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
     /// **Panics** if an index is out of bounds or stride is zero.<br>
     /// (**Panics** if `D` is `IxDyn` and `info` does not match the number of array axes.)
     pub fn islice(&mut self, indices: &D::SliceArg) {
-        let indices: &[SliceOrIndex] = indices.borrow();
+        let indices: &[SliceOrIndex] = indices.as_ref();
         assert_eq!(indices.len(), self.ndim());
         indices
             .iter()

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -257,17 +257,17 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         I: Borrow<SliceInfo<D::SliceArg, Do>>,
         Do: Dimension,
     {
-        let info: &SliceInfo<_, _> = info.borrow();
-        let indices: &[SliceOrIndex] = info.indices().borrow();
+        let info: &SliceInfo<D::SliceArg, Do> = info.borrow();
+        let indices: &D::SliceArg = info.borrow();
 
         // Slice and subview in-place without changing the number of dimensions.
-        self.islice(info.indices());
+        self.islice(indices);
 
         // Copy the dim and strides that remain after removing the subview axes.
         let out_ndim = info.out_ndim();
         let mut new_dim = Do::zero_index_with_ndim(out_ndim);
         let mut new_strides = Do::zero_index_with_ndim(out_ndim);
-        izip!(self.dim.slice(), self.strides.slice(), indices)
+        izip!(self.dim.slice(), self.strides.slice(), indices.borrow())
             .filter_map(|(d, s, slice_or_index)| match slice_or_index {
                 &SliceOrIndex::Slice(_) => Some((d, s)),
                 &SliceOrIndex::Index(_) => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,7 @@ pub type Ixs = isize;
 ///
 /// You can use slicing to create a view of a subset of the data in
 /// the array. Slicing methods include `.slice()`, `.slice_mut()`,
-/// `.slice_inplace()`.
+/// `.slice_move()`, and `.slice_inplace()`.
 ///
 /// The slicing argument can be passed using the macro [`s![]`](macro.s!.html),
 /// which will be used in all examples. (The explicit form is an instance of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,8 +421,8 @@ pub type Ixs = isize;
 /// ## Slicing
 ///
 /// You can use slicing to create a view of a subset of the data in
-/// the array. Slicing methods include `.slice()`, `.islice()`,
-/// `.slice_mut()`.
+/// the array. Slicing methods include `.slice()`, `.slice_mut()`,
+/// `.slice_inplace()`.
 ///
 /// The slicing argument can be passed using the macro [`s![]`](macro.s!.html),
 /// which will be used in all examples. (The explicit form is an instance of
@@ -478,8 +478,8 @@ pub type Ixs = isize;
 ///
 /// Subview methods allow you to restrict the array view while removing
 /// one axis from the array. Subview methods include `.subview()`,
-/// `.isubview()`, `.subview_mut()`. You can also take a subview by using a
-/// single index instead of a range when slicing.
+/// `.subview_inplace()`, `.subview_mut()`. You can also take a subview by
+/// using a single index instead of a range when slicing.
 ///
 /// Subview takes two arguments: `axis` and `index`.
 ///
@@ -527,7 +527,7 @@ pub type Ixs = isize;
 /// # }
 /// ```
 ///
-/// `.isubview()` modifies the view in the same way as `subview()`, but
+/// `.subview_inplace()` modifies the view in the same way as `subview()`, but
 /// since it is *in place*, it cannot remove the collapsed axis. It becomes
 /// an axis of length 1.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub use dimension::NdIndex;
 pub use dimension::IxDynImpl;
 pub use indexes::{indices, indices_of};
 pub use error::{ShapeError, ErrorKind};
-pub use si::{Si, S, SliceInfo, SliceNextDim, SliceOrIndex};
+pub use slice::{SliceInfo, SliceNextDim, SliceOrIndex};
 
 use iterators::Baseiter;
 use iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut};
@@ -143,7 +143,7 @@ mod free_functions;
 pub use free_functions::*;
 pub use iterators::iter;
 
-mod si;
+mod slice;
 mod layout;
 mod indexes;
 mod iterators;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub use dimension::NdIndex;
 pub use dimension::IxDynImpl;
 pub use indexes::{indices, indices_of};
 pub use error::{ShapeError, ErrorKind};
-pub use si::{Si, S};
+pub use si::{Si, S, SliceInfo, SliceNextDim, SliceOrIndex};
 
 use iterators::Baseiter;
 use iterators::{ElementsBase, ElementsBaseMut, Iter, IterMut};
@@ -425,9 +425,9 @@ pub type Ixs = isize;
 /// `.slice_mut()`.
 ///
 /// The slicing argument can be passed using the macro [`s![]`](macro.s!.html),
-/// which will be used in all examples. (The explicit form is a reference
-/// to a fixed size array of [`Si`]; see its docs for more information.)
-/// [`Si`]: struct.Si.html
+/// which will be used in all examples. (The explicit form is an instance of
+/// struct [`SliceInfo`]; see its docs for more information.)
+/// [`SliceInfo`]: struct.SliceInfo.html
 ///
 /// ```
 /// // import the s![] macro
@@ -478,12 +478,17 @@ pub type Ixs = isize;
 ///
 /// Subview methods allow you to restrict the array view while removing
 /// one axis from the array. Subview methods include `.subview()`,
-/// `.isubview()`, `.subview_mut()`.
+/// `.isubview()`, `.subview_mut()`. You can also take a subview by using a
+/// single index instead of a range when slicing.
 ///
 /// Subview takes two arguments: `axis` and `index`.
 ///
 /// ```
-/// use ndarray::{arr3, aview2, Axis};
+/// #[macro_use(s)] extern crate ndarray;
+///
+/// use ndarray::{arr3, aview1, aview2, Axis};
+///
+/// # fn main() {
 ///
 /// // 2 submatrices of 2 rows with 3 elements per row, means a shape of `[2, 2, 3]`.
 ///
@@ -513,6 +518,13 @@ pub type Ixs = isize;
 ///
 /// assert_eq!(sub_col, aview2(&[[ 1,  4],
 ///                              [ 7, 10]]));
+///
+/// // You can take multiple subviews at once (and slice at the same time)
+///
+/// let double_sub = a.slice(s![1, .., 0]);
+///
+/// assert_eq!(double_sub, aview1(&[7, 10]));
+/// # }
 /// ```
 ///
 /// `.isubview()` modifies the view in the same way as `subview()`, but

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,7 +445,7 @@ pub type Ixs = isize;
 /// #[macro_use(s)]
 /// extern crate ndarray;
 ///
-/// use ndarray::arr3;
+/// use ndarray::{arr2, arr3};
 ///
 /// fn main() {
 ///
@@ -488,7 +488,7 @@ pub type Ixs = isize;
 /// // - The last row in each submatrix, removing that axis: `-1`
 /// // - Row elements in reverse order: `..;-1`
 /// let f = a.slice(s![.., -1, ..;-1]);
-/// let g = arr3(&[[ 6,  5,  4],
+/// let g = arr2(&[[ 6,  5,  4],
 ///                [12, 11, 10]]);
 /// assert_eq!(f, g);
 /// assert_eq!(f.shape(), &[2, 3]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,13 +421,24 @@ pub type Ixs = isize;
 /// ## Slicing
 ///
 /// You can use slicing to create a view of a subset of the data in
-/// the array. Slicing methods include `.slice()`, `.slice_mut()`,
-/// `.slice_move()`, and `.slice_inplace()`.
+/// the array. Slicing methods include [`.slice()`], [`.slice_mut()`],
+/// [`.slice_move()`], and [`.slice_inplace()`].
 ///
 /// The slicing argument can be passed using the macro [`s![]`](macro.s!.html),
 /// which will be used in all examples. (The explicit form is an instance of
-/// struct [`SliceInfo`]; see its docs for more information.)
-/// [`SliceInfo`]: struct.SliceInfo.html
+/// [`&SliceInfo`]; see its docs for more information.)
+///
+/// [`&SliceInfo`]: struct.SliceInfo.html
+///
+/// If a range is used, the axis is preserved. If an index is used, a subview
+/// is taken with respect to the axis. See [*Subviews*](#subviews) for more
+/// information about subviews. Note that [`.slice_inplace()`] behaves like
+/// [`.subview_inplace()`] by preserving the number of dimensions.
+///
+/// [`.slice()`]: #method.slice
+/// [`.slice_mut()`]: #method.slice_mut
+/// [`.slice_move()`]: #method.slice_move
+/// [`.slice_inplace()`]: #method.slice_inplace
 ///
 /// ```
 /// // import the s![] macro
@@ -455,8 +466,6 @@ pub type Ixs = isize;
 /// // - Every element in each row: `..`
 ///
 /// let b = a.slice(s![.., 0..1, ..]);
-/// // without the macro, the explicit argument is `&[S, Si(0, Some(1), 1), S]`
-///
 /// let c = arr3(&[[[ 1,  2,  3]],
 ///                [[ 7,  8,  9]]]);
 /// assert_eq!(b, c);
@@ -471,17 +480,35 @@ pub type Ixs = isize;
 /// let e = arr3(&[[[ 6,  5,  4]],
 ///                [[12, 11, 10]]]);
 /// assert_eq!(d, e);
+/// assert_eq!(d.shape(), &[2, 1, 3]);
+///
+/// // Let’s create a slice while taking a subview with
+/// //
+/// // - Both submatrices of the greatest dimension: `..`
+/// // - The last row in each submatrix, removing that axis: `-1`
+/// // - Row elements in reverse order: `..;-1`
+/// let f = a.slice(s![.., -1, ..;-1]);
+/// let g = arr3(&[[ 6,  5,  4],
+///                [12, 11, 10]]);
+/// assert_eq!(f, g);
+/// assert_eq!(f.shape(), &[2, 3]);
 /// }
 /// ```
 ///
 /// ## Subviews
 ///
-/// Subview methods allow you to restrict the array view while removing
-/// one axis from the array. Subview methods include `.subview()`,
-/// `.subview_inplace()`, `.subview_mut()`. You can also take a subview by
-/// using a single index instead of a range when slicing.
+/// Subview methods allow you to restrict the array view while removing one
+/// axis from the array. Subview methods include [`.subview()`],
+/// [`.subview_mut()`], [`.into_subview()`], and [`.subview_inplace()`]. You
+/// can also take a subview by using a single index instead of a range when
+/// slicing.
 ///
 /// Subview takes two arguments: `axis` and `index`.
+///
+/// [`.subview()`]: #method.subview
+/// [`.subview_mut()`]: #method.subview_mut
+/// [`.into_subview()`]: #method.into_subview
+/// [`.subview_inplace()`]: #method.subview_inplace
 ///
 /// ```
 /// #[macro_use(s)] extern crate ndarray;
@@ -520,15 +547,13 @@ pub type Ixs = isize;
 ///                              [ 7, 10]]));
 ///
 /// // You can take multiple subviews at once (and slice at the same time)
-///
 /// let double_sub = a.slice(s![1, .., 0]);
-///
 /// assert_eq!(double_sub, aview1(&[7, 10]));
 /// # }
 /// ```
 ///
-/// `.subview_inplace()` modifies the view in the same way as `subview()`, but
-/// since it is *in place*, it cannot remove the collapsed axis. It becomes
+/// [`.subview_inplace()`] modifies the view in the same way as [`.subview()`],
+/// but since it is *in place*, it cannot remove the collapsed axis. It becomes
 /// an axis of length 1.
 ///
 /// `.outer_iter()` is an iterator of every subview along the zeroth (outer)

--- a/src/si.rs
+++ b/src/si.rs
@@ -112,6 +112,20 @@ pub enum SliceOrIndex {
 copy_and_clone!{SliceOrIndex}
 
 impl SliceOrIndex {
+    pub fn is_slice(&self) -> bool {
+        match self {
+            &SliceOrIndex::Slice(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_index(&self) -> bool {
+        match self {
+            &SliceOrIndex::Index(_) => true,
+            _ => false,
+        }
+    }
+
     #[inline]
     pub fn step(self, step: Ixs) -> Self {
         match self {
@@ -230,6 +244,16 @@ impl<'a> From<&'a [Si]> for SliceInfo<Vec<SliceOrIndex>, IxDyn> {
             out_dim: PhantomData,
             out_ndim: slices.len(),
             indices: slices.iter().map(|s| SliceOrIndex::Slice(*s)).collect(),
+        }
+    }
+}
+
+impl From<Vec<SliceOrIndex>> for SliceInfo<Vec<SliceOrIndex>, IxDyn> {
+    fn from(indices: Vec<SliceOrIndex>) -> Self {
+        SliceInfo {
+            out_dim: PhantomData,
+            out_ndim: indices.iter().filter(|s| s.is_slice()).count(),
+            indices: indices,
         }
     }
 }

--- a/src/si.rs
+++ b/src/si.rs
@@ -5,9 +5,11 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+use std::borrow::Borrow;
 use std::ops::{Range, RangeFrom, RangeTo, RangeFull};
 use std::fmt;
-use super::Ixs;
+use std::marker::PhantomData;
+use super::{Dim, Dimension, Ix, IxDyn, Ixs};
 
 // [a:b:s] syntax for example [:3], [::-1]
 // [0,:] -- first row of matrix
@@ -101,11 +103,177 @@ copy_and_clone!{Si}
 /// Slice value for the full range of an axis.
 pub const S: Si = Si(0, None, 1);
 
+#[derive(Debug, Eq, PartialEq)]
+pub enum SliceOrIndex {
+    Slice(Si),
+    Index(Ixs),
+}
+
+copy_and_clone!{SliceOrIndex}
+
+impl SliceOrIndex {
+    #[inline]
+    pub fn step(self, step: Ixs) -> Self {
+        match self {
+            SliceOrIndex::Slice(s) => SliceOrIndex::Slice(s.step(step)),
+            SliceOrIndex::Index(s) => SliceOrIndex::Index(s),
+        }
+    }
+}
+
+impl From<Range<Ixs>> for SliceOrIndex {
+    #[inline]
+    fn from(r: Range<Ixs>) -> SliceOrIndex {
+        SliceOrIndex::Slice(Si::from(r))
+    }
+}
+
+impl From<Ixs> for SliceOrIndex {
+    #[inline]
+    fn from(r: Ixs) -> SliceOrIndex {
+        SliceOrIndex::Index(r)
+    }
+}
+
+impl From<RangeFrom<Ixs>> for SliceOrIndex {
+    #[inline]
+    fn from(r: RangeFrom<Ixs>) -> SliceOrIndex {
+        SliceOrIndex::Slice(Si::from(r))
+    }
+}
+
+impl From<RangeTo<Ixs>> for SliceOrIndex {
+    #[inline]
+    fn from(r: RangeTo<Ixs>) -> SliceOrIndex {
+        SliceOrIndex::Slice(Si::from(r))
+    }
+}
+
+impl From<RangeFull> for SliceOrIndex {
+    #[inline]
+    fn from(r: RangeFull) -> SliceOrIndex {
+        SliceOrIndex::Slice(Si::from(r))
+    }
+}
+
+/// Represents all of the necessary information to perform a slice.
+pub struct SliceInfo<T, D: Dimension> {
+    out_dim: PhantomData<D>,
+    out_ndim: usize,
+    indices: T,
+}
+
+impl<T, D: Dimension> SliceInfo<T, D> {
+    /// Returns a new `SliceInfo` instance.
+    ///
+    /// If you call this method, you are guaranteeing that `out_dim` and
+    /// `out_ndim` are consistent with `indices`.
+    #[doc(hidden)]
+    pub unsafe fn new_unchecked(
+        indices: T,
+        out_dim: PhantomData<D>,
+        out_ndim: usize,
+    ) -> SliceInfo<T, D> {
+        SliceInfo {
+            out_dim: out_dim,
+            out_ndim: out_ndim,
+            indices: indices,
+        }
+    }
+
+    /// Returns a slice of the slice/index information.
+    pub fn indices(&self) -> &T {
+        &self.indices
+    }
+
+    /// Returns the number of dimensions after slicing.
+    pub fn out_ndim(&self) -> usize {
+        self.out_ndim
+    }
+}
+
+impl<T: Borrow<[SliceOrIndex]>, D: Dimension> AsRef<[SliceOrIndex]> for SliceInfo<T, D> {
+    fn as_ref(&self) -> &[SliceOrIndex] {
+        self.indices.borrow()
+    }
+}
+
+macro_rules! impl_sliceinfo_from_array {
+    ($ndim:expr) => {
+        impl From<[Si; $ndim]> for SliceInfo<[SliceOrIndex; $ndim], Dim<[Ix; $ndim]>> {
+            fn from(slices: [Si; $ndim]) -> Self {
+                let mut indices = [SliceOrIndex::Index(0); $ndim];
+                for (i, s) in slices.iter().enumerate() {
+                    indices[i] = SliceOrIndex::Slice(*s);
+                }
+                SliceInfo {
+                    out_dim: PhantomData,
+                    out_ndim: $ndim,
+                    indices: indices,
+                }
+            }
+        }
+    }
+}
+
+impl_sliceinfo_from_array!{0}
+impl_sliceinfo_from_array!{1}
+impl_sliceinfo_from_array!{2}
+impl_sliceinfo_from_array!{3}
+impl_sliceinfo_from_array!{4}
+impl_sliceinfo_from_array!{5}
+impl_sliceinfo_from_array!{6}
+
+impl<'a> From<&'a [Si]> for SliceInfo<Vec<SliceOrIndex>, IxDyn> {
+    fn from(slices: &[Si]) -> Self {
+        SliceInfo {
+            out_dim: PhantomData,
+            out_ndim: slices.len(),
+            indices: slices.iter().map(|s| SliceOrIndex::Slice(*s)).collect(),
+        }
+    }
+}
+
+#[doc(hidden)]
+pub trait SliceNextDim<D1, D2> {
+    fn next_dim(&self, (PhantomData<D1>, usize)) -> (PhantomData<D2>, usize);
+}
+
+impl<D1: Dimension> SliceNextDim<D1, D1::Larger> for Range<Ixs> {
+    fn next_dim(&self, (_dim, ndim): (PhantomData<D1>, usize)) -> (PhantomData<D1::Larger>, usize) {
+        (PhantomData, ndim + 1)
+    }
+}
+
+impl<D1: Dimension> SliceNextDim<D1, D1::Larger> for RangeFrom<Ixs> {
+    fn next_dim(&self, (_dim, ndim): (PhantomData<D1>, usize)) -> (PhantomData<D1::Larger>, usize) {
+        (PhantomData, ndim + 1)
+    }
+}
+
+impl<D1: Dimension> SliceNextDim<D1, D1::Larger> for RangeTo<Ixs> {
+    fn next_dim(&self, (_dim, ndim): (PhantomData<D1>, usize)) -> (PhantomData<D1::Larger>, usize) {
+        (PhantomData, ndim + 1)
+    }
+}
+
+impl<D1: Dimension> SliceNextDim<D1, D1::Larger> for RangeFull {
+    fn next_dim(&self, (_dim, ndim): (PhantomData<D1>, usize)) -> (PhantomData<D1::Larger>, usize) {
+        (PhantomData, ndim + 1)
+    }
+}
+
+impl<D1: Dimension> SliceNextDim<D1, D1> for Ixs {
+    fn next_dim(&self, (_dim, ndim): (PhantomData<D1>, usize)) -> (PhantomData<D1>, usize) {
+        (PhantomData, ndim)
+    }
+}
+
 /// Slice argument constructor.
 ///
 /// `s![]` takes a list of ranges, separated by comma, with optional strides
-/// that are separated from the range by a semicolon.
-/// It is converted into a slice argument with type `&[Si; N]`.
+/// that are separated from the range by a semicolon. It is converted into a
+/// `SliceInfo` instance.
 ///
 /// Each range uses signed indices, where a negative value is counted from
 /// the end of the axis. Strides are also signed and may be negative, but
@@ -120,10 +288,6 @@ pub const S: Si = Si(0, None, 1);
 /// For example `s![0..4;2, 1..5]` is a slice of rows 0..4 with step size 2,
 /// and columns 1..5 with default step size 1. The slice would have
 /// shape `[2, 4]`.
-///
-/// If an array has two axes, the slice argument is passed as
-/// type `&[Si; 2]`.  The macro expansion of `s![a..b;c, d..e]`
-/// is equivalent to `&[Si(a, Some(b), c), Si(d, Some(e), 1)]`.
 ///
 /// ```
 /// #[macro_use]
@@ -143,34 +307,54 @@ pub const S: Si = Si(0, None, 1);
 #[macro_export]
 macro_rules! s(
     // convert a..b;c into @step(a..b, c), final item
-    (@parse [$($stack:tt)*] $r:expr;$s:expr) => {
-        &[$($stack)* s!(@step $r, $s)]
+    (@parse $dim_ndim:expr, [$($stack:tt)*] $r:expr;$s:expr) => {
+        {
+            let (out_dim, out_ndim) = $crate::SliceNextDim::next_dim(&$r, $dim_ndim);
+            unsafe {
+                $crate::SliceInfo::new_unchecked([$($stack)* s!(@step $r, $s)], out_dim, out_ndim)
+            }
+        }
     };
     // convert a..b into @step(a..b, 1), final item
-    (@parse [$($stack:tt)*] $r:expr) => {
-        &[$($stack)* s!(@step $r, 1)]
+    (@parse $dim_ndim:expr, [$($stack:tt)*] $r:expr) => {
+        {
+            let (out_dim, out_ndim) = $crate::SliceNextDim::next_dim(&$r, $dim_ndim);
+            unsafe {
+                $crate::SliceInfo::new_unchecked([$($stack)* s!(@step $r, 1)], out_dim, out_ndim)
+            }
+        }
     };
     // convert a..b;c into @step(a..b, c), final item, trailing comma
-    (@parse [$($stack:tt)*] $r:expr;$s:expr ,) => {
-        &[$($stack)* s!(@step $r, $s)]
+    (@parse $dim_ndim:expr, [$($stack:tt)*] $r:expr;$s:expr ,) => {
+        {
+            let (out_dim, out_ndim) = $crate::SliceNextDim::next_dim(&$r, $dim_ndim);
+            unsafe {
+                $crate::SliceInfo::new_unchecked([$($stack)* s!(@step $r, $s)], out_dim, out_ndim)
+            }
+        }
     };
     // convert a..b into @step(a..b, 1), final item, trailing comma
-    (@parse [$($stack:tt)*] $r:expr ,) => {
-        &[$($stack)* s!(@step $r, 1)]
+    (@parse $dim_ndim:expr, [$($stack:tt)*] $r:expr ,) => {
+        {
+            let (out_dim, out_ndim) = $crate::SliceNextDim::next_dim(&$r, $dim_ndim);
+            unsafe {
+                $crate::SliceInfo::new_unchecked([$($stack)* s!(@step $r, 1)], out_dim, out_ndim)
+            }
+        }
     };
     // convert a..b;c into @step(a..b, c)
-    (@parse [$($stack:tt)*] $r:expr;$s:expr, $($t:tt)*) => {
-        s![@parse [$($stack)* s!(@step $r, $s),] $($t)*]
+    (@parse $dim_ndim:expr, [$($stack:tt)*] $r:expr;$s:expr, $($t:tt)*) => {
+        s![@parse $crate::SliceNextDim::next_dim(&$r, $dim_ndim), [$($stack)* s!(@step $r, $s),] $($t)*]
     };
     // convert a..b into @step(a..b, 1)
-    (@parse [$($stack:tt)*] $r:expr, $($t:tt)*) => {
-        s![@parse [$($stack)* s!(@step $r, 1),] $($t)*]
+    (@parse $dim_ndim:expr, [$($stack:tt)*] $r:expr, $($t:tt)*) => {
+        s![@parse $crate::SliceNextDim::next_dim(&$r, $dim_ndim), [$($stack)* s!(@step $r, 1),] $($t)*]
     };
-    // convert range, step into Si
+    // convert range, step into SliceOrIndex
     (@step $r:expr, $s:expr) => {
-        <$crate::Si as ::std::convert::From<_>>::from($r).step($s)
+        <$crate::SliceOrIndex as ::std::convert::From<_>>::from($r).step($s)
     };
     ($($t:tt)*) => {
-        s![@parse [] $($t)*]
+        s![@parse (::std::marker::PhantomData::<$crate::Ix0>, 0), [] $($t)*]
     };
 );

--- a/src/si.rs
+++ b/src/si.rs
@@ -192,9 +192,9 @@ impl<T, D: Dimension> SliceInfo<T, D> {
     }
 }
 
-impl<T: Borrow<[SliceOrIndex]>, D: Dimension> AsRef<[SliceOrIndex]> for SliceInfo<T, D> {
-    fn as_ref(&self) -> &[SliceOrIndex] {
-        self.indices.borrow()
+impl<T, D: Dimension> Borrow<T> for SliceInfo<T, D> {
+    fn borrow(&self) -> &T {
+        &self.indices
     }
 }
 

--- a/src/si.rs
+++ b/src/si.rs
@@ -234,6 +234,16 @@ where
     }
 }
 
+impl<T, D> AsRef<[SliceOrIndex]> for SliceInfo<T, D>
+where
+    T: AsRef<[SliceOrIndex]>,
+    D: Dimension,
+{
+    fn as_ref(&self) -> &[SliceOrIndex] {
+        self.indices.as_ref()
+    }
+}
+
 impl<T, D> AsRef<SliceInfo<[SliceOrIndex], D>> for SliceInfo<T, D>
 where
     T: AsRef<[SliceOrIndex]>,

--- a/src/si.rs
+++ b/src/si.rs
@@ -230,12 +230,64 @@ where
     }
 }
 
-impl<T: ?Sized, D> Borrow<T> for SliceInfo<T, D>
+impl<T: ?Sized, D> SliceInfo<T, D>
 where
     D: Dimension,
 {
-    fn borrow(&self) -> &T {
+    pub fn indices(&self) -> &T {
         &self.indices
+    }
+}
+
+macro_rules! impl_borrow_array_for_sliceinfo {
+    ($ndim:expr) => {
+        impl<T: ?Sized, D> Borrow<[SliceOrIndex; $ndim]> for SliceInfo<T, D>
+        where
+            T: Borrow<[SliceOrIndex; $ndim]>,
+            D: Dimension,
+        {
+            fn borrow(&self) -> &[SliceOrIndex; $ndim] {
+                self.indices.borrow()
+            }
+        }
+
+        impl<'a, T: ?Sized, D> Borrow<[SliceOrIndex; $ndim]> for &'a SliceInfo<T, D>
+        where
+            T: Borrow<[SliceOrIndex; $ndim]>,
+            D: Dimension,
+        {
+            fn borrow(&self) -> &[SliceOrIndex; $ndim] {
+                (*self).borrow()
+            }
+        }
+    }
+}
+
+impl_borrow_array_for_sliceinfo!(0);
+impl_borrow_array_for_sliceinfo!(1);
+impl_borrow_array_for_sliceinfo!(2);
+impl_borrow_array_for_sliceinfo!(3);
+impl_borrow_array_for_sliceinfo!(4);
+impl_borrow_array_for_sliceinfo!(5);
+impl_borrow_array_for_sliceinfo!(6);
+
+impl<T: ?Sized, D> Borrow<[SliceOrIndex]> for SliceInfo<T, D>
+where
+    T: Borrow<[SliceOrIndex]>,
+    D: Dimension,
+{
+    fn borrow(&self) -> &[SliceOrIndex] {
+        self.indices.borrow()
+    }
+}
+
+impl<'a, T: ?Sized, D> Borrow<[SliceOrIndex]> for &'a SliceInfo<T, D>
+where
+    T: Borrow<[SliceOrIndex]>,
+    D: Dimension,
+{
+    fn borrow(&self) -> &[SliceOrIndex] {
+        (*self).borrow()
     }
 }
 
@@ -253,6 +305,16 @@ where
             &*(self.indices.borrow() as *const [SliceOrIndex]
                 as *const SliceInfo<[SliceOrIndex], D>)
         }
+    }
+}
+
+impl<'a, T, D> Borrow<SliceInfo<[SliceOrIndex], D>> for &'a SliceInfo<T, D>
+where
+    T: Borrow<[SliceOrIndex]>,
+    D: Dimension,
+{
+    fn borrow(&self) -> &SliceInfo<[SliceOrIndex], D> {
+        (*self).borrow()
     }
 }
 

--- a/src/si.rs
+++ b/src/si.rs
@@ -5,7 +5,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use std::borrow::Borrow;
 use std::ops::{Range, RangeFrom, RangeTo, RangeFull, Deref};
 use std::fmt;
 use std::marker::PhantomData;
@@ -200,14 +199,14 @@ where
 
 impl<T, D> SliceInfo<T, D>
 where
-    T: Borrow<[SliceOrIndex]>,
+    T: AsRef<[SliceOrIndex]>,
     D: Dimension,
 {
     /// Returns a new `SliceInfo` instance.
     ///
     /// **Panics** if `D` is not consistent with `indices`.
     pub fn new(indices: T) -> SliceInfo<T, D> {
-        let out_ndim = indices.borrow().iter().filter(|s| s.is_slice()).count();
+        let out_ndim = indices.as_ref().iter().filter(|s| s.is_slice()).count();
         if let Some(ndim) = D::NDIM {
             assert_eq!(out_ndim, ndim);
         }
@@ -220,14 +219,14 @@ where
 
 impl<T: ?Sized, D> SliceInfo<T, D>
 where
-    T: Borrow<[SliceOrIndex]>,
+    T: AsRef<[SliceOrIndex]>,
     D: Dimension,
 {
     /// Returns the number of dimensions after slicing and taking subviews.
     pub fn out_ndim(&self) -> usize {
         D::NDIM.unwrap_or_else(|| {
             self.indices
-                .borrow()
+                .as_ref()
                 .iter()
                 .filter(|s| s.is_slice())
                 .count()
@@ -235,18 +234,18 @@ where
     }
 }
 
-impl<T, D> Borrow<SliceInfo<[SliceOrIndex], D>> for SliceInfo<T, D>
+impl<T, D> AsRef<SliceInfo<[SliceOrIndex], D>> for SliceInfo<T, D>
 where
-    T: Borrow<[SliceOrIndex]>,
+    T: AsRef<[SliceOrIndex]>,
     D: Dimension,
 {
-    fn borrow(&self) -> &SliceInfo<[SliceOrIndex], D> {
+    fn as_ref(&self) -> &SliceInfo<[SliceOrIndex], D> {
         unsafe {
             // This is okay because the only non-zero-sized member of
             // `SliceInfo` is `indices`, so `&SliceInfo<[SliceOrIndex], D>`
             // should have the same bitwise representation as
             // `&[SliceOrIndex]`.
-            &*(self.indices.borrow() as *const [SliceOrIndex]
+            &*(self.indices.as_ref() as *const [SliceOrIndex]
                 as *const SliceInfo<[SliceOrIndex], D>)
         }
     }

--- a/src/si.rs
+++ b/src/si.rs
@@ -250,7 +250,8 @@ where
             // `SliceInfo` is `indices`, so `&SliceInfo<[SliceOrIndex], D>`
             // should have the same bitwise representation as
             // `&[SliceOrIndex]`.
-            ::std::mem::transmute(self.indices.borrow())
+            &*(self.indices.borrow() as *const [SliceOrIndex]
+                as *const SliceInfo<[SliceOrIndex], D>)
         }
     }
 }

--- a/src/si.rs
+++ b/src/si.rs
@@ -173,7 +173,7 @@ impl From<RangeFull> for SliceOrIndex {
 /// Represents all of the necessary information to perform a slice.
 pub struct SliceInfo<T: ?Sized, D: Dimension> {
     out_dim: PhantomData<D>,
-    pub(crate) indices: T,
+    indices: T,
 }
 
 impl<T: ?Sized, D> Deref for SliceInfo<T, D> where D: Dimension {

--- a/src/si.rs
+++ b/src/si.rs
@@ -256,6 +256,20 @@ where
     }
 }
 
+impl<T, D> Clone for SliceInfo<T, D>
+where
+    T: Clone,
+    D: Dimension,
+{
+    fn clone(&self) -> Self {
+        SliceInfo {
+            out_dim: PhantomData,
+            indices: self.indices.clone(),
+        }
+    }
+}
+
+
 #[doc(hidden)]
 pub trait SliceNextDim<D1, D2> {
     fn next_dim(&self, PhantomData<D1>) -> PhantomData<D2>;

--- a/src/si.rs
+++ b/src/si.rs
@@ -171,7 +171,7 @@ impl From<RangeFull> for SliceOrIndex {
 }
 
 /// Represents all of the necessary information to perform a slice.
-pub struct SliceInfo<T, D: Dimension> {
+pub struct SliceInfo<T: ?Sized, D: Dimension> {
     out_dim: PhantomData<D>,
     out_ndim: usize,
     indices: T,
@@ -194,7 +194,9 @@ impl<T, D: Dimension> SliceInfo<T, D> {
             indices: indices,
         }
     }
+}
 
+impl<T: ?Sized, D: Dimension> SliceInfo<T, D> {
     /// Returns a slice of the slice/index information.
     pub fn indices(&self) -> &T {
         &self.indices
@@ -206,7 +208,7 @@ impl<T, D: Dimension> SliceInfo<T, D> {
     }
 }
 
-impl<T, D: Dimension> Borrow<T> for SliceInfo<T, D> {
+impl<T: ?Sized, D: Dimension> Borrow<T> for SliceInfo<T, D> {
     fn borrow(&self) -> &T {
         &self.indices
     }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -125,6 +125,7 @@ impl From<RangeFull> for SliceOrIndex {
 }
 
 /// Represents all of the necessary information to perform a slice.
+#[repr(C)]
 pub struct SliceInfo<T: ?Sized, D: Dimension> {
     out_dim: PhantomData<D>,
     indices: T,

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use std::ops::{Range, RangeFrom, RangeTo, RangeFull, Deref};
+use std::ops::{Deref, Range, RangeFrom, RangeFull, RangeTo};
 use std::fmt;
 use std::marker::PhantomData;
 use super::{Dimension, Ixs};
@@ -130,9 +130,14 @@ pub struct SliceInfo<T: ?Sized, D: Dimension> {
     indices: T,
 }
 
-impl<T: ?Sized, D> Deref for SliceInfo<T, D> where D: Dimension {
+impl<T: ?Sized, D> Deref for SliceInfo<T, D>
+where
+    D: Dimension,
+{
     type Target = T;
-    fn deref(&self) -> &Self::Target { &self.indices }
+    fn deref(&self) -> &Self::Target {
+        &self.indices
+    }
 }
 
 impl<T, D> SliceInfo<T, D>
@@ -220,7 +225,8 @@ impl<T, D> Copy for SliceInfo<T, D>
 where
     T: Copy,
     D: Dimension,
-{ }
+{
+}
 
 impl<T, D> Clone for SliceInfo<T, D>
 where
@@ -311,25 +317,37 @@ macro_rules! s(
     // convert a..b;c into @step(a..b, c), final item
     (@parse $dim:expr, [$($stack:tt)*] $r:expr;$s:expr) => {
         unsafe {
-            &$crate::SliceInfo::new_unchecked([$($stack)* s!(@step $r, $s)], $crate::SliceNextDim::next_dim(&$r, $dim))
+            &$crate::SliceInfo::new_unchecked(
+                [$($stack)* s!(@step $r, $s)],
+                $crate::SliceNextDim::next_dim(&$r, $dim),
+            )
         }
     };
     // convert a..b into @step(a..b, 1), final item
     (@parse $dim:expr, [$($stack:tt)*] $r:expr) => {
         unsafe {
-            &$crate::SliceInfo::new_unchecked([$($stack)* s!(@step $r, 1)], $crate::SliceNextDim::next_dim(&$r, $dim))
+            &$crate::SliceInfo::new_unchecked(
+                [$($stack)* s!(@step $r, 1)],
+                $crate::SliceNextDim::next_dim(&$r, $dim),
+            )
         }
     };
     // convert a..b;c into @step(a..b, c), final item, trailing comma
     (@parse $dim:expr, [$($stack:tt)*] $r:expr;$s:expr ,) => {
         unsafe {
-            &$crate::SliceInfo::new_unchecked([$($stack)* s!(@step $r, $s)], $crate::SliceNextDim::next_dim(&$r, $dim))
+            &$crate::SliceInfo::new_unchecked(
+                [$($stack)* s!(@step $r, $s)],
+                $crate::SliceNextDim::next_dim(&$r, $dim),
+            )
         }
     };
     // convert a..b into @step(a..b, 1), final item, trailing comma
     (@parse $dim:expr, [$($stack:tt)*] $r:expr ,) => {
         unsafe {
-            &$crate::SliceInfo::new_unchecked([$($stack)* s!(@step $r, 1)], $crate::SliceNextDim::next_dim(&$r, $dim))
+            &$crate::SliceInfo::new_unchecked(
+                [$($stack)* s!(@step $r, 1)],
+                $crate::SliceNextDim::next_dim(&$r, $dim),
+            )
         }
     };
     // convert a..b;c into @step(a..b, c)

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -6,7 +6,7 @@ extern crate ndarray;
 extern crate defmac;
 extern crate itertools;
 
-use ndarray::Si;
+use ndarray::{Si, SliceInfo, SliceOrIndex};
 use ndarray::prelude::*;
 use ndarray::{
     rcarr2,
@@ -65,6 +65,164 @@ fn test_slice()
     let vi = A.slice(s![.., ..]);
     assert_eq!(vi.shape(), A.shape());
     assert!(vi.iter().zip(A.iter()).all(|(a, b)| a == b));
+}
+
+#[test]
+fn test_slice_array_fixed()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5));
+    let info = s![1.., ..;2];
+    arr.slice(info.clone());
+    arr.slice_mut(info.clone());
+    arr.view().slice_into(info.clone());
+    arr.view().islice(info.clone());
+}
+
+#[test]
+fn test_slice_array_fixed_ref()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5));
+    let info = s![1.., ..;2];
+    arr.slice(&info);
+    arr.slice_mut(&info);
+    arr.view().slice_into(&info);
+    arr.view().islice(&info);
+}
+
+#[test]
+fn test_slice_dyninput_array_fixed()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
+    let info = s![1.., ..;2];
+    arr.slice(info.clone());
+    arr.slice_mut(info.clone());
+    arr.view().slice_into(info.clone());
+    arr.view().islice(info.clone());
+
+}
+
+#[test]
+fn test_slice_dyninput_array_fixed_ref()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
+    let info = s![1.., ..;2];
+    arr.slice(&info);
+    arr.slice_mut(&info);
+    arr.view().slice_into(&info);
+    arr.view().islice(&info);
+
+}
+
+#[test]
+fn test_slice_array_dyn()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5));
+    let info = SliceInfo::<_, IxDyn>::new([
+        SliceOrIndex::Slice(Si::from(1..)),
+        SliceOrIndex::Slice(Si::from(..).step(2)),
+    ]);
+    arr.slice(info.clone());
+    arr.slice_mut(info.clone());
+    arr.view().slice_into(info.clone());
+    arr.view().islice(info.clone());
+}
+
+#[test]
+fn test_slice_array_dyn_ref()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5));
+    let info = SliceInfo::<_, IxDyn>::new([
+        SliceOrIndex::Slice(Si::from(1..)),
+        SliceOrIndex::Slice(Si::from(..).step(2)),
+    ]);
+    arr.slice(&info);
+    arr.slice_mut(&info);
+    arr.view().slice_into(&info);
+    arr.view().islice(&info);
+}
+
+#[test]
+fn test_slice_dyninput_array_dyn()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
+    let info = SliceInfo::<_, IxDyn>::new([
+        SliceOrIndex::Slice(Si::from(1..)),
+        SliceOrIndex::Slice(Si::from(..).step(2)),
+    ]);
+    arr.slice(info.clone());
+    arr.slice_mut(info.clone());
+    arr.view().slice_into(info.clone());
+    arr.view().islice(info.clone());
+}
+
+#[test]
+fn test_slice_dyninput_array_dyn_ref()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
+    let info = SliceInfo::<_, IxDyn>::new([
+        SliceOrIndex::Slice(Si::from(1..)),
+        SliceOrIndex::Slice(Si::from(..).step(2)),
+    ]);
+    arr.slice(&info);
+    arr.slice_mut(&info);
+    arr.view().slice_into(&info);
+    arr.view().islice(&info);
+}
+
+#[test]
+fn test_slice_dyninput_vec_fixed()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
+    let info = SliceInfo::<_, Ix2>::new(vec![
+        SliceOrIndex::Slice(Si::from(1..)),
+        SliceOrIndex::Slice(Si::from(..).step(2)),
+    ]);
+    arr.slice(info.clone());
+    arr.slice_mut(info.clone());
+    arr.view().slice_into(info.clone());
+    arr.view().islice(info.clone());
+}
+
+#[test]
+fn test_slice_dyninput_vec_fixed_ref()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
+    let info = SliceInfo::<_, Ix2>::new(vec![
+        SliceOrIndex::Slice(Si::from(1..)),
+        SliceOrIndex::Slice(Si::from(..).step(2)),
+    ]);
+    arr.slice(&info);
+    arr.slice_mut(&info);
+    arr.view().slice_into(&info);
+    arr.view().islice(&info);
+}
+
+#[test]
+fn test_slice_dyninput_vec_dyn()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
+    let info = SliceInfo::<_, IxDyn>::new(vec![
+        SliceOrIndex::Slice(Si::from(1..)),
+        SliceOrIndex::Slice(Si::from(..).step(2)),
+    ]);
+    arr.slice(info.clone());
+    arr.slice_mut(info.clone());
+    arr.view().slice_into(info.clone());
+    arr.view().islice(info.clone());
+}
+
+#[test]
+fn test_slice_dyninput_vec_dyn_ref()
+{
+    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
+    let info = SliceInfo::<_, IxDyn>::new(vec![
+        SliceOrIndex::Slice(Si::from(1..)),
+        SliceOrIndex::Slice(Si::from(..).step(2)),
+    ]);
+    arr.slice(&info);
+    arr.slice_mut(&info);
+    arr.view().slice_into(&info);
+    arr.view().islice(&info);
 }
 
 #[test]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -74,7 +74,7 @@ fn test_slice_array_fixed()
     let info = s![1.., ..;2];
     arr.slice(info);
     arr.slice_mut(info);
-    arr.view().slice_into(info);
+    arr.view().slice_move(info);
     arr.view().slice_inplace(info);
 }
 
@@ -85,7 +85,7 @@ fn test_slice_dyninput_array_fixed()
     let info = s![1.., ..;2];
     arr.slice(info);
     arr.slice_mut(info);
-    arr.view().slice_into(info);
+    arr.view().slice_move(info);
     arr.view().slice_inplace(info.as_ref());
 }
 
@@ -99,7 +99,7 @@ fn test_slice_array_dyn()
     ]);
     arr.slice(info);
     arr.slice_mut(info);
-    arr.view().slice_into(info);
+    arr.view().slice_move(info);
     arr.view().slice_inplace(info);
 }
 
@@ -113,7 +113,7 @@ fn test_slice_dyninput_array_dyn()
     ]);
     arr.slice(info);
     arr.slice_mut(info);
-    arr.view().slice_into(info);
+    arr.view().slice_move(info);
     arr.view().slice_inplace(info.as_ref());
 }
 
@@ -127,7 +127,7 @@ fn test_slice_dyninput_vec_fixed()
     ]);
     arr.slice(info.as_ref());
     arr.slice_mut(info.as_ref());
-    arr.view().slice_into(info.as_ref());
+    arr.view().slice_move(info.as_ref());
     arr.view().slice_inplace(info.as_ref());
 }
 
@@ -141,7 +141,7 @@ fn test_slice_dyninput_vec_dyn()
     ]);
     arr.slice(info.as_ref());
     arr.slice_mut(info.as_ref());
-    arr.view().slice_into(info.as_ref());
+    arr.view().slice_move(info.as_ref());
     arr.view().slice_inplace(info.as_ref());
 }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -86,7 +86,7 @@ fn test_slice_dyninput_array_fixed()
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_into(info);
-    arr.view().islice(&**info);
+    arr.view().islice(info.as_ref());
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn test_slice_dyninput_array_dyn()
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_into(info);
-    arr.view().islice(&**info);
+    arr.view().islice(info.as_ref());
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn test_slice_dyninput_vec_fixed()
     arr.slice(info.as_ref());
     arr.slice_mut(info.as_ref());
     arr.view().slice_into(info.as_ref());
-    arr.view().islice(&*info);
+    arr.view().islice(info.as_ref());
 }
 
 #[test]
@@ -142,7 +142,7 @@ fn test_slice_dyninput_vec_dyn()
     arr.slice(info.as_ref());
     arr.slice_mut(info.as_ref());
     arr.view().slice_into(info.as_ref());
-    arr.view().islice(&*info);
+    arr.view().islice(info.as_ref());
 }
 
 #[test]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -14,6 +14,7 @@ use ndarray::{
 };
 use ndarray::indices;
 use itertools::{enumerate, zip};
+use std::borrow::Borrow;
 
 #[test]
 fn test_matmul_rcarray()
@@ -72,21 +73,10 @@ fn test_slice_array_fixed()
 {
     let mut arr = Array2::<f64>::zeros((5, 5));
     let info = s![1.., ..;2];
-    arr.slice(info.clone());
-    arr.slice_mut(info.clone());
-    arr.view().slice_into(info.clone());
-    arr.view().islice(info.clone());
-}
-
-#[test]
-fn test_slice_array_fixed_ref()
-{
-    let mut arr = Array2::<f64>::zeros((5, 5));
-    let info = s![1.., ..;2];
-    arr.slice(&info);
-    arr.slice_mut(&info);
-    arr.view().slice_into(&info);
-    arr.view().islice(&info);
+    arr.slice(info);
+    arr.slice_mut(info);
+    arr.view().slice_into(info);
+    arr.view().islice(info);
 }
 
 #[test]
@@ -94,135 +84,66 @@ fn test_slice_dyninput_array_fixed()
 {
     let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
     let info = s![1.., ..;2];
-    arr.slice(info.clone());
-    arr.slice_mut(info.clone());
-    arr.view().slice_into(info.clone());
-    arr.view().islice(info.clone());
-
-}
-
-#[test]
-fn test_slice_dyninput_array_fixed_ref()
-{
-    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
-    let info = s![1.., ..;2];
-    arr.slice(&info);
-    arr.slice_mut(&info);
-    arr.view().slice_into(&info);
-    arr.view().islice(&info);
-
+    arr.slice(info);
+    arr.slice_mut(info);
+    arr.view().slice_into(info);
+    arr.view().islice(&**info);
 }
 
 #[test]
 fn test_slice_array_dyn()
 {
     let mut arr = Array2::<f64>::zeros((5, 5));
-    let info = SliceInfo::<_, IxDyn>::new([
+    let info = &SliceInfo::<_, IxDyn>::new([
         SliceOrIndex::Slice(Si::from(1..)),
         SliceOrIndex::Slice(Si::from(..).step(2)),
     ]);
-    arr.slice(info.clone());
-    arr.slice_mut(info.clone());
-    arr.view().slice_into(info.clone());
-    arr.view().islice(info.clone());
-}
-
-#[test]
-fn test_slice_array_dyn_ref()
-{
-    let mut arr = Array2::<f64>::zeros((5, 5));
-    let info = SliceInfo::<_, IxDyn>::new([
-        SliceOrIndex::Slice(Si::from(1..)),
-        SliceOrIndex::Slice(Si::from(..).step(2)),
-    ]);
-    arr.slice(&info);
-    arr.slice_mut(&info);
-    arr.view().slice_into(&info);
-    arr.view().islice(&info);
+    arr.slice(info);
+    arr.slice_mut(info);
+    arr.view().slice_into(info);
+    arr.view().islice(info);
 }
 
 #[test]
 fn test_slice_dyninput_array_dyn()
 {
     let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
-    let info = SliceInfo::<_, IxDyn>::new([
+    let info = &SliceInfo::<_, IxDyn>::new([
         SliceOrIndex::Slice(Si::from(1..)),
         SliceOrIndex::Slice(Si::from(..).step(2)),
     ]);
-    arr.slice(info.clone());
-    arr.slice_mut(info.clone());
-    arr.view().slice_into(info.clone());
-    arr.view().islice(info.clone());
-}
-
-#[test]
-fn test_slice_dyninput_array_dyn_ref()
-{
-    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
-    let info = SliceInfo::<_, IxDyn>::new([
-        SliceOrIndex::Slice(Si::from(1..)),
-        SliceOrIndex::Slice(Si::from(..).step(2)),
-    ]);
-    arr.slice(&info);
-    arr.slice_mut(&info);
-    arr.view().slice_into(&info);
-    arr.view().islice(&info);
+    arr.slice(info);
+    arr.slice_mut(info);
+    arr.view().slice_into(info);
+    arr.view().islice(&**info);
 }
 
 #[test]
 fn test_slice_dyninput_vec_fixed()
 {
     let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
-    let info = SliceInfo::<_, Ix2>::new(vec![
+    let info = &SliceInfo::<_, Ix2>::new(vec![
         SliceOrIndex::Slice(Si::from(1..)),
         SliceOrIndex::Slice(Si::from(..).step(2)),
     ]);
-    arr.slice(info.clone());
-    arr.slice_mut(info.clone());
-    arr.view().slice_into(info.clone());
-    arr.view().islice(info.clone());
-}
-
-#[test]
-fn test_slice_dyninput_vec_fixed_ref()
-{
-    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
-    let info = SliceInfo::<_, Ix2>::new(vec![
-        SliceOrIndex::Slice(Si::from(1..)),
-        SliceOrIndex::Slice(Si::from(..).step(2)),
-    ]);
-    arr.slice(&info);
-    arr.slice_mut(&info);
-    arr.view().slice_into(&info);
-    arr.view().islice(&info);
+    arr.slice(info.borrow());
+    arr.slice_mut(info.borrow());
+    arr.view().slice_into(info.borrow());
+    arr.view().islice(&*info);
 }
 
 #[test]
 fn test_slice_dyninput_vec_dyn()
 {
     let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
-    let info = SliceInfo::<_, IxDyn>::new(vec![
+    let info = &SliceInfo::<_, IxDyn>::new(vec![
         SliceOrIndex::Slice(Si::from(1..)),
         SliceOrIndex::Slice(Si::from(..).step(2)),
     ]);
-    arr.slice(info.clone());
-    arr.slice_mut(info.clone());
-    arr.view().slice_into(info.clone());
-    arr.view().islice(info.clone());
-}
-
-#[test]
-fn test_slice_dyninput_vec_dyn_ref()
-{
-    let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
-    let info = SliceInfo::<_, IxDyn>::new(vec![
-        SliceOrIndex::Slice(Si::from(1..)),
-        SliceOrIndex::Slice(Si::from(..).step(2)),
-    ]);
-    arr.slice(&info);
-    arr.slice_mut(&info);
-    arr.view().slice_into(&info);
-    arr.view().islice(&info);
+    arr.slice(info.borrow());
+    arr.slice_mut(info.borrow());
+    arr.view().slice_into(info.borrow());
+    arr.view().islice(&*info);
 }
 
 #[test]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -6,7 +6,7 @@ extern crate ndarray;
 extern crate defmac;
 extern crate itertools;
 
-use ndarray::{S, Si, SliceInfo};
+use ndarray::Si;
 use ndarray::prelude::*;
 use ndarray::{
     rcarr2,
@@ -62,7 +62,7 @@ fn test_slice()
 
     let vi = A.slice(s![1.., ..;2]);
     assert_eq!(vi.shape(), &[2, 2]);
-    let vi = A.slice(SliceInfo::from([S, S]));
+    let vi = A.slice(s![.., ..]);
     assert_eq!(vi.shape(), A.shape());
     assert!(vi.iter().zip(A.iter()).all(|(a, b)| a == b));
 }
@@ -136,7 +136,7 @@ fn index_out_of_bounds() {
 fn slice_oob()
 {
     let a = RcArray::<i32, _>::zeros((3, 4));
-    let _vi = a.slice(SliceInfo::from([Si(0, Some(10), 1), S]));
+    let _vi = a.slice(s![..10, ..]);
 }
 
 #[should_panic]
@@ -166,7 +166,7 @@ fn test_index()
         assert_eq!(*a, A[[i, j]]);
     }
 
-    let vi = A.slice(SliceInfo::from([Si(1, None, 1), Si(0, None, 2)]));
+    let vi = A.slice(s![1.., ..;2]);
     let mut it = vi.iter();
     for ((i, j), x) in zip(indices((1, 2)), &mut it) {
         assert_eq!(*x, vi[[i, j]]);
@@ -235,7 +235,7 @@ fn test_negative_stride_rcarray()
     }
 
     {
-        let vi = mat.slice(SliceInfo::from([S, Si(0, None, -1), Si(0, None, -1)]));
+        let vi = mat.slice(s![.., ..;-1, ..;-1]);
         assert_eq!(vi.shape(), &[2, 4, 2]);
         // Test against sequential iterator
         let seq = [7f32,6., 5.,4.,3.,2.,1.,0.,15.,14.,13., 12.,11.,  10.,   9.,   8.];
@@ -267,7 +267,7 @@ fn test_cow()
     assert_eq!(n[[0, 1]], 0);
     assert_eq!(n.get((0, 1)), Some(&0));
     let mut rev = mat.reshape(4);
-    rev.islice(SliceInfo::from([Si(0, None, -1)]));
+    rev.islice(s![..;-1]);
     assert_eq!(rev[0], 4);
     assert_eq!(rev[1], 3);
     assert_eq!(rev[2], 2);
@@ -431,7 +431,7 @@ fn assign()
     let mut a = arr2(&[[1, 2], [3, 4]]);
     {
         let mut v = a.view_mut();
-        v.islice(SliceInfo::from([Si(0, Some(1), 1), S]));
+        v.islice(s![..1, ..]);
         v.fill(0);
     }
     assert_eq!(a, arr2(&[[0, 0], [3, 4]]));
@@ -731,7 +731,7 @@ fn view_mut() {
 #[test]
 fn slice_mut() {
     let mut a = RcArray::from_vec(vec![1, 2, 3, 4]).reshape((2, 2));
-    for elt in a.slice_mut(SliceInfo::from([S, S])) {
+    for elt in a.slice_mut(s![.., ..]) {
         *elt = 0;
     }
     assert_eq!(a, aview2(&[[0, 0], [0, 0]]));
@@ -739,14 +739,14 @@ fn slice_mut() {
     let mut b = arr2(&[[1, 2, 3],
                        [4, 5, 6]]);
     let c = b.clone(); // make sure we can mutate b even if it has to be unshared first
-    for elt in b.slice_mut(SliceInfo::from([S, Si(0, Some(1), 1)])) {
+    for elt in b.slice_mut(s![.., ..1]) {
         *elt = 0;
     }
     assert_eq!(b, aview2(&[[0, 2, 3],
                            [0, 5, 6]]));
     assert!(c != b);
 
-    for elt in b.slice_mut(SliceInfo::from([S, Si(0, None, 2)])) {
+    for elt in b.slice_mut(s![.., ..;2]) {
         *elt = 99;
     }
     assert_eq!(b, aview2(&[[99, 2, 99],

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -143,7 +143,7 @@ fn slice_oob()
 #[test]
 fn slice_axis_oob() {
     let a = RcArray::<i32, _>::zeros((3, 4));
-    let _vi = a.slice_axis(Axis(0), &Si(0, Some(10), 1));
+    let _vi = a.slice_axis(Axis(0), Si(0, Some(10), 1));
 }
 
 #[should_panic]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -6,7 +6,7 @@ extern crate ndarray;
 extern crate defmac;
 extern crate itertools;
 
-use ndarray::{Si, SliceInfo, SliceOrIndex};
+use ndarray::{SliceInfo, SliceOrIndex};
 use ndarray::prelude::*;
 use ndarray::{
     rcarr2,
@@ -94,8 +94,8 @@ fn test_slice_array_dyn()
 {
     let mut arr = Array2::<f64>::zeros((5, 5));
     let info = &SliceInfo::<_, IxDyn>::new([
-        SliceOrIndex::Slice(Si::from(1..)),
-        SliceOrIndex::Slice(Si::from(..).step(2)),
+        SliceOrIndex::from(1..),
+        SliceOrIndex::from(..).step(2),
     ]);
     arr.slice(info);
     arr.slice_mut(info);
@@ -108,8 +108,8 @@ fn test_slice_dyninput_array_dyn()
 {
     let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
     let info = &SliceInfo::<_, IxDyn>::new([
-        SliceOrIndex::Slice(Si::from(1..)),
-        SliceOrIndex::Slice(Si::from(..).step(2)),
+        SliceOrIndex::from(1..),
+        SliceOrIndex::from(..).step(2),
     ]);
     arr.slice(info);
     arr.slice_mut(info);
@@ -122,8 +122,8 @@ fn test_slice_dyninput_vec_fixed()
 {
     let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
     let info = &SliceInfo::<_, Ix2>::new(vec![
-        SliceOrIndex::Slice(Si::from(1..)),
-        SliceOrIndex::Slice(Si::from(..).step(2)),
+        SliceOrIndex::from(1..),
+        SliceOrIndex::from(..).step(2),
     ]);
     arr.slice(info.as_ref());
     arr.slice_mut(info.as_ref());
@@ -136,8 +136,8 @@ fn test_slice_dyninput_vec_dyn()
 {
     let mut arr = Array2::<f64>::zeros((5, 5)).into_dyn();
     let info = &SliceInfo::<_, IxDyn>::new(vec![
-        SliceOrIndex::Slice(Si::from(1..)),
-        SliceOrIndex::Slice(Si::from(..).step(2)),
+        SliceOrIndex::from(1..),
+        SliceOrIndex::from(..).step(2),
     ]);
     arr.slice(info.as_ref());
     arr.slice_mut(info.as_ref());
@@ -221,7 +221,7 @@ fn slice_oob()
 #[test]
 fn slice_axis_oob() {
     let a = RcArray::<i32, _>::zeros((3, 4));
-    let _vi = a.slice_axis(Axis(0), Si(0, Some(10), 1));
+    let _vi = a.slice_axis(Axis(0), 0, Some(10), 1);
 }
 
 #[should_panic]

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -75,7 +75,7 @@ fn test_slice_array_fixed()
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_into(info);
-    arr.view().islice(info);
+    arr.view().slice_inplace(info);
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn test_slice_dyninput_array_fixed()
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_into(info);
-    arr.view().islice(info.as_ref());
+    arr.view().slice_inplace(info.as_ref());
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn test_slice_array_dyn()
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_into(info);
-    arr.view().islice(info);
+    arr.view().slice_inplace(info);
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn test_slice_dyninput_array_dyn()
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_into(info);
-    arr.view().islice(info.as_ref());
+    arr.view().slice_inplace(info.as_ref());
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn test_slice_dyninput_vec_fixed()
     arr.slice(info.as_ref());
     arr.slice_mut(info.as_ref());
     arr.view().slice_into(info.as_ref());
-    arr.view().islice(info.as_ref());
+    arr.view().slice_inplace(info.as_ref());
 }
 
 #[test]
@@ -142,7 +142,7 @@ fn test_slice_dyninput_vec_dyn()
     arr.slice(info.as_ref());
     arr.slice_mut(info.as_ref());
     arr.view().slice_into(info.as_ref());
-    arr.view().islice(info.as_ref());
+    arr.view().slice_inplace(info.as_ref());
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn test_slice_with_subview()
 }
 
 #[test]
-fn test_islice_with_isubview()
+fn test_slice_inplace_with_subview_inplace()
 {
     let mut A = RcArray::<usize, _>::zeros((3, 5, 4));
     for (i, elt) in A.iter_mut().enumerate() {
@@ -184,7 +184,7 @@ fn test_islice_with_isubview()
     }
 
     let mut vi = A.view();
-    vi.islice(s![1.., 2, ..;2]);
+    vi.slice_inplace(s![1.., 2, ..;2]);
     assert_eq!(vi.shape(), &[2, 1, 2]);
     assert!(
         vi.iter()
@@ -193,7 +193,7 @@ fn test_islice_with_isubview()
     );
 
     let mut vi = A.view();
-    vi.islice(s![1, 2, ..;2]);
+    vi.slice_inplace(s![1, 2, ..;2]);
     assert_eq!(vi.shape(), &[1, 1, 2]);
     assert!(
         vi.iter()
@@ -345,7 +345,7 @@ fn test_cow()
     assert_eq!(n[[0, 1]], 0);
     assert_eq!(n.get((0, 1)), Some(&0));
     let mut rev = mat.reshape(4);
-    rev.islice(s![..;-1]);
+    rev.slice_inplace(s![..;-1]);
     assert_eq!(rev[0], 4);
     assert_eq!(rev[1], 3);
     assert_eq!(rev[2], 2);
@@ -370,7 +370,7 @@ fn test_cow_shrink()
     // mutation shrinks the array and gives it different strides
     //
     let mut mat = RcArray::zeros((2, 3));
-    //mat.islice(s![.., ..;2]);
+    //mat.slice_inplace(s![.., ..;2]);
     mat[[0, 0]] = 1;
     let n = mat.clone();
     mat[[0, 1]] = 2;
@@ -385,7 +385,7 @@ fn test_cow_shrink()
     assert_eq!(n.get((0, 1)), Some(&0));
     // small has non-C strides this way
     let mut small = mat.reshape(6);
-    small.islice(s![4..;-1]);
+    small.slice_inplace(s![4..;-1]);
     assert_eq!(small[0], 6);
     assert_eq!(small[1], 5);
     let before = small.clone();
@@ -509,7 +509,7 @@ fn assign()
     let mut a = arr2(&[[1, 2], [3, 4]]);
     {
         let mut v = a.view_mut();
-        v.islice(s![..1, ..]);
+        v.slice_inplace(s![..1, ..]);
         v.fill(0);
     }
     assert_eq!(a, arr2(&[[0, 0], [3, 4]]));
@@ -1215,7 +1215,7 @@ fn to_owned_memory_order() {
 fn to_owned_neg_stride() {
     let mut c = arr2(&[[1, 2, 3],
                        [4, 5, 6]]);
-    c.islice(s![.., ..;-1]);
+    c.slice_inplace(s![.., ..;-1]);
     let co = c.to_owned();
     assert_eq!(c, co);
 }
@@ -1380,10 +1380,10 @@ fn test_to_vec() {
                        [7, 8, 9],
                        [10,11,12]]);
 
-    a.islice(s![..;-1, ..]);
+    a.slice_inplace(s![..;-1, ..]);
     assert_eq!(a.row(3).to_vec(), vec![1, 2, 3]);
     assert_eq!(a.column(2).to_vec(), vec![12, 9, 6, 3]);
-    a.islice(s![.., ..;-1]);
+    a.slice_inplace(s![.., ..;-1]);
     assert_eq!(a.row(3).to_vec(), vec![3, 2, 1]);
 }
 
@@ -1399,7 +1399,7 @@ fn test_array_clone_unalias() {
 #[test]
 fn test_array_clone_same_view() {
     let mut a = Array::from_iter(0..9).into_shape((3, 3)).unwrap();
-    a.islice(s![..;-1, ..;-1]);
+    a.slice_inplace(s![..;-1, ..;-1]);
     let b = a.clone();
     assert_eq!(a, b);
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -14,7 +14,6 @@ use ndarray::{
 };
 use ndarray::indices;
 use itertools::{enumerate, zip};
-use std::borrow::Borrow;
 
 #[test]
 fn test_matmul_rcarray()
@@ -126,9 +125,9 @@ fn test_slice_dyninput_vec_fixed()
         SliceOrIndex::Slice(Si::from(1..)),
         SliceOrIndex::Slice(Si::from(..).step(2)),
     ]);
-    arr.slice(info.borrow());
-    arr.slice_mut(info.borrow());
-    arr.view().slice_into(info.borrow());
+    arr.slice(info.as_ref());
+    arr.slice_mut(info.as_ref());
+    arr.view().slice_into(info.as_ref());
     arr.view().islice(&*info);
 }
 
@@ -140,9 +139,9 @@ fn test_slice_dyninput_vec_dyn()
         SliceOrIndex::Slice(Si::from(1..)),
         SliceOrIndex::Slice(Si::from(..).step(2)),
     ]);
-    arr.slice(info.borrow());
-    arr.slice_mut(info.borrow());
-    arr.view().slice_into(info.borrow());
+    arr.slice(info.as_ref());
+    arr.slice_mut(info.as_ref());
+    arr.view().slice_into(info.as_ref());
     arr.view().islice(&*info);
 }
 

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -53,7 +53,7 @@ fn remove_axis()
     a.subview(Axis(1), 0);
 
     let a = RcArray::<f32, _>::zeros(vec![4,5,6]);
-    let _b = a.subview_move(Axis(1), 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
+    let _b = a.into_subview(Axis(1), 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
 }
 
 #[test]

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -53,7 +53,7 @@ fn remove_axis()
     a.subview(Axis(1), 0);
 
     let a = RcArray::<f32, _>::zeros(vec![4,5,6]);
-    let _b = a.into_subview(Axis(1), 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
+    let _b = a.subview_move(Axis(1), 0).reshape((4, 6)).reshape(vec![2, 3, 4]);
 }
 
 #[test]

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -4,7 +4,7 @@ extern crate itertools;
 
 use ndarray::{Array0, Array2};
 use ndarray::RcArray;
-use ndarray::{Ix, Si, S};
+use ndarray::{Ix, Si, S, SliceInfo};
 use ndarray::{
     ArrayBase,
     Data,
@@ -99,22 +99,22 @@ fn as_slice() {
     assert_slice_correct(&v.subview(Axis(0), 0));
     assert_slice_correct(&v.subview(Axis(0), 1));
 
-    assert!(v.slice(&[S, Si(0, Some(1), 1)]).as_slice().is_none());
-    println!("{:?}", v.slice(&[Si(0, Some(1), 2), S]));
-    assert!(v.slice(&[Si(0, Some(1), 2), S]).as_slice().is_some());
+    assert!(v.slice(SliceInfo::from([S, Si(0, Some(1), 1)])).as_slice().is_none());
+    println!("{:?}", v.slice(SliceInfo::from([Si(0, Some(1), 2), S])));
+    assert!(v.slice(SliceInfo::from([Si(0, Some(1), 2), S])).as_slice().is_some());
 
     // `u` is contiguous, because the column stride of `2` doesn't matter
     // when the result is just one row anyway -- length of that dimension is 1
-    let u = v.slice(&[Si(0, Some(1), 2), S]);
+    let u = v.slice(SliceInfo::from([Si(0, Some(1), 2), S]));
     println!("{:?}", u.shape());
     println!("{:?}", u.strides());
-    println!("{:?}", v.slice(&[Si(0, Some(1), 2), S]));
+    println!("{:?}", v.slice(SliceInfo::from([Si(0, Some(1), 2), S])));
     assert!(u.as_slice().is_some());
     assert_slice_correct(&u);
 
     let a = a.reshape((8, 1));
     assert_slice_correct(&a);
-    let u = a.slice(&[Si(0, None, 2), S]);
+    let u = a.slice(SliceInfo::from([Si(0, None, 2), S]));
     println!("u={:?}, shape={:?}, strides={:?}", u, u.shape(), u.strides());
     assert!(u.as_slice().is_none());
 }

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -4,7 +4,7 @@ extern crate itertools;
 
 use ndarray::{Array0, Array2};
 use ndarray::RcArray;
-use ndarray::{Ix, Si, S, SliceInfo};
+use ndarray::Ix;
 use ndarray::{
     ArrayBase,
     Data,
@@ -99,22 +99,22 @@ fn as_slice() {
     assert_slice_correct(&v.subview(Axis(0), 0));
     assert_slice_correct(&v.subview(Axis(0), 1));
 
-    assert!(v.slice(SliceInfo::from([S, Si(0, Some(1), 1)])).as_slice().is_none());
-    println!("{:?}", v.slice(SliceInfo::from([Si(0, Some(1), 2), S])));
-    assert!(v.slice(SliceInfo::from([Si(0, Some(1), 2), S])).as_slice().is_some());
+    assert!(v.slice(s![.., ..1]).as_slice().is_none());
+    println!("{:?}", v.slice(s![..1;2, ..]));
+    assert!(v.slice(s![..1;2, ..]).as_slice().is_some());
 
     // `u` is contiguous, because the column stride of `2` doesn't matter
     // when the result is just one row anyway -- length of that dimension is 1
-    let u = v.slice(SliceInfo::from([Si(0, Some(1), 2), S]));
+    let u = v.slice(s![..1;2, ..]);
     println!("{:?}", u.shape());
     println!("{:?}", u.strides());
-    println!("{:?}", v.slice(SliceInfo::from([Si(0, Some(1), 2), S])));
+    println!("{:?}", v.slice(s![..1;2, ..]));
     assert!(u.as_slice().is_some());
     assert_slice_correct(&u);
 
     let a = a.reshape((8, 1));
     assert_slice_correct(&a);
-    let u = a.slice(SliceInfo::from([Si(0, None, 2), S]));
+    let u = a.slice(s![..;2, ..]);
     println!("u={:?}, shape={:?}, strides={:?}", u, u.shape(), u.strides());
     assert!(u.as_slice().is_none());
 }

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -7,7 +7,7 @@ use ndarray::{rcarr1, rcarr2};
 use ndarray::{LinalgScalar, Data};
 use ndarray::linalg::general_mat_mul;
 use ndarray::linalg::general_mat_vec_mul;
-use ndarray::Si;
+use ndarray::{Si, SliceInfo};
 use ndarray::{Ix, Ixs};
 
 use std::fmt;
@@ -570,7 +570,7 @@ fn scaled_add_3() {
 
                 {
                     let mut av = a.slice_mut(s![..;s1, ..;s2]);
-                    let c = c.slice(&cslice);
+                    let c = c.slice(SliceInfo::from(&*cslice));
 
                     let mut answerv = answer.slice_mut(s![..;s1, ..;s2]);
                     answerv += &(beta * &c);

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -7,9 +7,7 @@ use ndarray::{rcarr1, rcarr2};
 use ndarray::{LinalgScalar, Data};
 use ndarray::linalg::general_mat_mul;
 use ndarray::linalg::general_mat_vec_mul;
-use ndarray::{Si, SliceInfo};
-use ndarray::SliceOrIndex::Slice;
-use ndarray::{Ix, Ixs};
+use ndarray::{Ix, Ixs, SliceInfo, SliceOrIndex};
 
 use std::fmt;
 use num_traits::Float;
@@ -562,9 +560,12 @@ fn scaled_add_3() {
                     vec![n, q]
                 };
                 let cslice = if n == 1 {
-                    vec![Slice(Si(0, None, s2))]
+                    vec![SliceOrIndex::from(..).step(s2)]
                 } else {
-                    vec![Slice(Si(0, None, s1)), Slice(Si(0, None, s2))]
+                    vec![
+                        SliceOrIndex::from(..).step(s1),
+                        SliceOrIndex::from(..).step(s2),
+                    ]
                 };
 
                 let c = range_mat64(n, q).into_shape(cdim).unwrap();

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -11,7 +11,6 @@ use ndarray::{Si, SliceInfo};
 use ndarray::SliceOrIndex::Slice;
 use ndarray::{Ix, Ixs};
 
-use std::borrow::Borrow;
 use std::fmt;
 use num_traits::Float;
 
@@ -572,7 +571,7 @@ fn scaled_add_3() {
 
                 {
                     let mut av = a.slice_mut(s![..;s1, ..;s2]);
-                    let c = c.slice(SliceInfo::<_, IxDyn>::new(cslice).borrow());
+                    let c = c.slice(SliceInfo::<_, IxDyn>::new(cslice).as_ref());
 
                     let mut answerv = answer.slice_mut(s![..;s1, ..;s2]);
                     answerv += &(beta * &c);

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -11,6 +11,7 @@ use ndarray::{Si, SliceInfo};
 use ndarray::SliceOrIndex::Slice;
 use ndarray::{Ix, Ixs};
 
+use std::borrow::Borrow;
 use std::fmt;
 use num_traits::Float;
 
@@ -571,7 +572,7 @@ fn scaled_add_3() {
 
                 {
                     let mut av = a.slice_mut(s![..;s1, ..;s2]);
-                    let c = c.slice(SliceInfo::<_, IxDyn>::new(cslice));
+                    let c = c.slice(SliceInfo::<_, IxDyn>::new(cslice).borrow());
 
                     let mut answerv = answer.slice_mut(s![..;s1, ..;s2]);
                     answerv += &(beta * &c);

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -8,6 +8,7 @@ use ndarray::{LinalgScalar, Data};
 use ndarray::linalg::general_mat_mul;
 use ndarray::linalg::general_mat_vec_mul;
 use ndarray::{Si, SliceInfo};
+use ndarray::SliceOrIndex::Slice;
 use ndarray::{Ix, Ixs};
 
 use std::fmt;
@@ -561,16 +562,16 @@ fn scaled_add_3() {
                     vec![n, q]
                 };
                 let cslice = if n == 1 {
-                    vec![Si(0, None, s2)]
+                    vec![Slice(Si(0, None, s2))]
                 } else {
-                    vec![Si(0, None, s1), Si(0, None, s2)]
+                    vec![Slice(Si(0, None, s1)), Slice(Si(0, None, s2))]
                 };
 
                 let c = range_mat64(n, q).into_shape(cdim).unwrap();
 
                 {
                     let mut av = a.slice_mut(s![..;s1, ..;s2]);
-                    let c = c.slice(SliceInfo::from(&*cslice));
+                    let c = c.slice(SliceInfo::<_, IxDyn>::new(cslice));
 
                     let mut answerv = answer.slice_mut(s![..;s1, ..;s2]);
                     answerv += &(beta * &c);


### PR DESCRIPTION
Please don't merge this PR immediately. It needs some refinement, including updated documentation and more tests.

This is an implementation of #215, adding support for taking subviews while slicing. A few of the changes are:
* The `s!` macro can take individual indices (to indicate subviews) in addition to ranges.
* The `s!` macro returns an *owned* `SliceInfo` instance instead of just a reference, so the caller can easily pass it around between methods.
* The various `*slice*()` methods now take a `SliceInfo` instance (or reference).
* There's now a `slice_into()` method. Note that ideally we'd come up with a better name than `slice_into` because there's already an `into_slice()` method.
* `ArrayBase` now has three additional methods `*slice_axis*()` that slice along a single axis.

The primary disadvantage of this change is that it's not easy to create a `SliceInfo` instance without the `s!` macro. If that's an important feature, it would be possible to do any (or all) of the following:
* Add `impl<'a> From<&'a [SliceOrIndex]> for SliceInfo<Vec<SliceOrIndex>, IxDyn>`.
* Add a macro to convert `[SliceOrIndex; n]` into `SliceInfo<[SliceOrIndex; n], D>`, where `D` is determined at compile time.
* Add a function to convert `[SliceOrIndex; n]` into `SliceInfo<[SliceOrIndex; n], D>`, where the caller would have to specify `D`, and `D` would be checked at runtime.

Note that this PR is a breaking change.

Will you please let me know what you think?