### PR TITLE
Get a correct reference to an element from ArrayView

### DIFF
--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -94,6 +94,46 @@ impl<S, D, I> IndexMut<I> for ArrayBase<S, D>
     }
 }
 
+impl<'a, A, D> ArrayView<'a, A, D>
+where
+    D: Dimension,
+{
+    /// Get a reference of a element through the view.
+    ///
+    /// This is a replacement of `Index::index` since it forces us a wrong lifetime
+    /// https://github.com/bluss/rust-ndarray/issues/371
+    pub fn elem_ref<I: NdIndex<D>>(&self, index: I) -> &'a A {
+        debug_bounds_check!(self, index);
+        unsafe {
+            &*self.as_ptr().offset(
+                index
+                    .index_checked(&self.dim, &self.strides)
+                    .unwrap_or_else(|| array_out_of_bounds()),
+            )
+        }
+    }
+}
+
+impl<'a, A, D> ArrayViewMut<'a, A, D>
+where
+    D: Dimension,
+{
+    /// Get a mutable reference of a element through the view.
+    ///
+    /// This is a replacement of `IndexMut::index_mut` since it forces us a wrong lifetime
+    /// https://github.com/bluss/rust-ndarray/issues/371
+    pub fn elem_ref_mut<I: NdIndex<D>>(&mut self, index: I) -> &'a mut A {
+        debug_bounds_check!(self, index);
+        unsafe {
+            &mut *self.as_mut_ptr().offset(
+                index
+                    .index_checked(&self.dim, &self.strides)
+                    .unwrap_or_else(|| array_out_of_bounds()),
+            )
+        }
+    }
+}
+
 /// Return `true` if the array shapes and all elements of `self` and
 /// `rhs` are equal. Return `false` otherwise.
 impl<S, S2, D> PartialEq<ArrayBase<S2, D>> for ArrayBase<S, D>

--- a/src/arraytraits.rs
+++ b/src/arraytraits.rs
@@ -102,7 +102,7 @@ where
     ///
     /// This is a replacement of `Index::index` since it forces us a wrong lifetime
     /// https://github.com/bluss/rust-ndarray/issues/371
-    pub fn elem_ref<I: NdIndex<D>>(&self, index: I) -> &'a A {
+    pub fn elem<I: NdIndex<D>>(&self, index: I) -> &'a A {
         debug_bounds_check!(self, index);
         unsafe {
             &*self.as_ptr().offset(
@@ -112,23 +112,39 @@ where
             )
         }
     }
+
+    /// Get a reference of a element through the view without boundary check
+    ///
+    /// This is a replacement of `Index::index` since it forces us a wrong lifetime
+    /// https://github.com/bluss/rust-ndarray/issues/371
+    pub fn uelem<I: NdIndex<D>>(&self, index: I) -> &'a A {
+        debug_bounds_check!(self, index);
+        unsafe { &*self.as_ptr().offset(index.index_unchecked(&self.strides)) }
+    }
 }
 
 impl<'a, A, D> ArrayViewMut<'a, A, D>
 where
     D: Dimension,
 {
-    /// Get a mutable reference of a element through the view.
-    ///
-    /// This is a replacement of `IndexMut::index_mut` since it forces us a wrong lifetime
-    /// https://github.com/bluss/rust-ndarray/issues/371
-    pub fn elem_ref_mut<I: NdIndex<D>>(&mut self, index: I) -> &'a mut A {
+    /// Convert a mutable array view to a mutable reference of a element.
+    pub fn into_elem<I: NdIndex<D>>(mut self, index: I) -> &'a mut A {
         debug_bounds_check!(self, index);
         unsafe {
             &mut *self.as_mut_ptr().offset(
                 index
                     .index_checked(&self.dim, &self.strides)
                     .unwrap_or_else(|| array_out_of_bounds()),
+            )
+        }
+    }
+
+    /// Convert a mutable array view to a mutable reference of a element without boundary check
+    pub fn into_elem_unchecked<I: NdIndex<D>>(mut self, index: I) -> &'a mut A {
+        debug_bounds_check!(self, index);
+        unsafe {
+            &mut *self.as_mut_ptr().offset(
+                index.index_unchecked(&self.strides),
             )
         }
     }


### PR DESCRIPTION
Revival of #371 
Since `Index` trait does not allow us to change the lifetime, I implement it as an associated function `ArrayView::elem_ref` and `ArrayViewMut::elem_ref_mut`