### PR TITLE
MAINT: use len_of(...) instead of shape().axis(...)

### DIFF
--- a/src/impl_2d.rs
+++ b/src/impl_2d.rs
@@ -32,7 +32,7 @@ impl<A, S> ArrayBase<S, Ix2>
 
     /// Return the number of rows (length of `Axis(0)`) in the two-dimensional array.
     pub fn rows(&self) -> usize {
-        self.shape().axis(Axis(0))
+        self.len_of(Axis(0))
     }
 
     /// Return an array view of column `index`.
@@ -54,7 +54,7 @@ impl<A, S> ArrayBase<S, Ix2>
 
     /// Return the number of columns (length of `Axis(1)`) in the two-dimensional array.
     pub fn cols(&self) -> usize {
-        self.shape().axis(Axis(1))
+        self.len_of(Axis(1))
     }
 
     /// Return true if the array is square, false otherwise.

--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -1611,7 +1611,7 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
               F: FnMut(ArrayView1<'a, A>) -> B,
               A: 'a,
     {
-        let view_len = self.shape().axis(axis);
+        let view_len = self.len_of(axis);
         let view_stride = self.strides.axis(axis);
         // use the 0th subview as a map to each 1d array view extended from
         // the 0th element.

--- a/src/impl_views.rs
+++ b/src/impl_views.rs
@@ -94,9 +94,9 @@ impl<'a, A, D> ArrayView<'a, A, D>
         -> (Self, Self)
     {
         // NOTE: Keep this in sync with the ArrayViewMut version
-        assert!(index <= self.shape().axis(axis));
+        assert!(index <= self.len_of(axis));
         let left_ptr = self.ptr;
-        let right_ptr = if index == self.shape().axis(axis) {
+        let right_ptr = if index == self.len_of(axis) {
             self.ptr
         } else {
             let offset = stride_offset(index, self.strides.axis(axis));
@@ -200,9 +200,9 @@ impl<'a, A, D> ArrayViewMut<'a, A, D>
         -> (Self, Self)
     {
         // NOTE: Keep this in sync with the ArrayView version
-        assert!(index <= self.shape().axis(axis));
+        assert!(index <= self.len_of(axis));
         let left_ptr = self.ptr;
-        let right_ptr = if index == self.shape().axis(axis) {
+        let right_ptr = if index == self.len_of(axis) {
             self.ptr
         } else {
             let offset = stride_offset(index, self.strides.axis(axis));

--- a/src/numeric/impl_numeric.rs
+++ b/src/numeric/impl_numeric.rs
@@ -70,7 +70,7 @@ impl<A, S, D> ArrayBase<S, D>
         where A: Clone + Zero + Add<Output=A>,
               D: RemoveAxis,
     {
-        let n = self.shape().axis(axis);
+        let n = self.len_of(axis);
         let mut res = self.subview(axis, 0).to_owned();
         let stride = self.strides()[axis.index()];
         if self.ndim() == 2 && stride == 1 {
@@ -115,7 +115,7 @@ impl<A, S, D> ArrayBase<S, D>
         where A: LinalgScalar,
               D: RemoveAxis,
     {
-        let n = self.shape().axis(axis);
+        let n = self.len_of(axis);
         let sum = self.sum_axis(axis);
         let mut cnt = A::one();
         for _ in 1..n {

--- a/src/stacking.rs
+++ b/src/stacking.rs
@@ -46,8 +46,7 @@ pub fn stack<'a, A, D>(axis: Axis, arrays: &[ArrayView<'a, A, D>])
         return Err(from_kind(ErrorKind::IncompatibleShape));
     }
 
-    let stacked_dim = arrays.iter()
-                            .fold(0, |acc, a| acc + a.shape().axis(axis));
+    let stacked_dim = arrays.iter().fold(0, |acc, a| acc + a.len_of(axis));
     res_dim.set_axis(axis, stacked_dim);
 
     // we can safely use uninitialized values here because they are Copy
@@ -62,7 +61,7 @@ pub fn stack<'a, A, D>(axis: Axis, arrays: &[ArrayView<'a, A, D>])
     {
         let mut assign_view = res.view_mut();
         for array in arrays {
-            let len = array.shape().axis(axis);
+            let len = array.len_of(axis);
             let (mut front, rest) = assign_view.split_at(axis, len);
             front.assign(array);
             assign_view = rest;


### PR DESCRIPTION
The `len_of` method is an equivalent and slightly more direct way of
getting the length of an axis.