### PR TITLE
Fix trait bound on arr1 (op) &arr2

### DIFF
--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -82,7 +82,7 @@ impl<A, S, S2, D, E> $trt<ArrayBase<S2, E>> for ArrayBase<S, D>
 /// **Panics** if broadcasting isn’t possible.
 impl<'a, A, S, S2, D, E> $trt<&'a ArrayBase<S2, E>> for ArrayBase<S, D>
     where A: Clone + $trt<A, Output=A>,
-          S: DataMut<Elem=A>,
+          S: DataOwned<Elem=A> + DataMut,
           S2: Data<Elem=A>,
           D: Dimension,
           E: Dimension,


### PR DESCRIPTION
The implementation of `arr1 (op) &arr2` mutates `arr1` for efficiency, but this caused surprising behavior if `arr1` was `ArrayViewMut`. This commit requires that `arr` own its data to avoid surprising side effects.

This is an example of the old behavior that was surprising:

```rust
extern crate ndarray;

fn main() {
    let mut a = array![1., 2.];
    let b = array![3., 4.];

    // Prints a = [1, 2].
    println!("a = {}", a);

    {
        let a_view_mut = a.view_mut();
        // Prints a + b = [4, 6].
        println!("a + b = {}", a_view_mut + &b);
    }

    // Prints a = [4, 6]; would expect a = [1, 2].
    println!("a = {}", a);
}
```

Note that while this is a breaking change, the stricter trait bound is actually the correct bound according to the documentation.