### PR TITLE
Add .into_owned() for all arrays with S: DataOwned

### DIFF
--- a/src/impl_methods.rs
+++ b/src/impl_methods.rs
@@ -144,6 +144,15 @@ impl<A, S, D> ArrayBase<S, D> where S: Data<Elem=A>, D: Dimension
         self.to_owned().into_shared()
     }
 
+    /// Turn the array into a uniquely owned array, cloning the array elements
+    /// to unshare them if necessary.
+    pub fn into_owned(self) -> Array<A, D>
+        where A: Clone,
+              S: DataOwned,
+    {
+        S::into_owned(self)
+    }
+
     /// Turn the array into a shared ownership (copy on write) array,
     /// without any copying.
     pub fn into_shared(self) -> RcArray<A, D>

--- a/src/impl_owned_array.rs
+++ b/src/impl_owned_array.rs
@@ -1,10 +1,4 @@
-
-use std::rc::Rc;
-
 use imp_prelude::*;
-use {
-    OwnedRepr,
-};
 
 /// Methods specific to `Array`.
 ///
@@ -21,28 +15,5 @@ impl<A, D> Array<A, D>
     /// of the array (`.iter()` order) and of the returned vector will be the same.
     pub fn into_raw_vec(self) -> Vec<A> {
         self.data.0
-    }
-}
-
-/// Methods specific to `RcArray`.
-///
-/// ***See also all methods for [`ArrayBase`]***
-///
-/// [`ArrayBase`]: struct.ArrayBase.html
-impl<A, D> RcArray<A, D>
-    where A: Clone,
-          D: Dimension
-{
-    /// Convert an `RcArray` into `Array`; cloning the array elements to unshare
-    /// them if necessary.
-    pub fn into_owned(mut self) -> Array<A, D> {
-        <_>::ensure_unique(&mut self);
-        let data = OwnedRepr(Rc::try_unwrap(self.data.0).ok().unwrap());
-        ArrayBase {
-            data: data,
-            ptr: self.ptr,
-            dim: self.dim,
-            strides: self.strides,
-        }
     }
 }


### PR DESCRIPTION
This is useful for generic code that needs to get a uniquely owned array but only knows that `S: DataOwned`. Before, `.into_owned()` only existed for `RcArray`.