### PR TITLE
Add .nth() method to Slice type

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -48,6 +48,48 @@ impl Slice {
     pub fn step_by(self, step: Ixs) -> Self {
         Slice { step, ..self }
     }
+
+    /// Returns the `n`th index in this slice.
+    ///
+    /// The `n` argument starts from zero, so `nth(0)` is the first index. If
+    /// `n` is greater than or equal to the length of the slice, then the
+    /// return value is `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ndarray::Slice;
+    ///
+    /// // indices 0, 1, 2, 3, 4
+    /// assert_eq!(Slice::new(0, Some(5), 1).nth(2), Some(2));
+    ///
+    /// // indices 1, 3
+    /// assert_eq!(Slice::new(1, Some(5), 2).nth(1), Some(3));
+    ///
+    /// // indices 1, -1, -3
+    /// assert_eq!(Slice::new(1, Some(-4), -2).nth(2), Some(-3));
+    ///
+    /// // indices 1, 3, 5, ...
+    /// assert_eq!(Slice::new(1, None, 2).nth(2), Some(5));
+    ///
+    /// // indices 3, 3, 3, ...
+    /// assert_eq!(Slice::new(3, Some(5), 0).nth(1000), Some(3));
+    ///
+    /// // indices 1, 3
+    /// assert_eq!(Slice::new(1, Some(5), 2).nth(2), None);
+    /// ```
+    pub fn nth(&self, n: usize) -> Option<isize> {
+        let nth = self.start + self.step * n as isize;
+        if let Some(end) = self.end {
+            if self.step == 0 || (self.step > 0 && nth < end) || (self.step < 0 && nth > end) {
+                Some(nth)
+            } else {
+                None
+            }
+        } else {
+            Some(nth)
+        }
+    }
 }
 
 impl From<Range<Ixs>> for Slice {


### PR DESCRIPTION
This PR adds an `nth()` method for the `Slice` type.

Instead of adding an `nth()` method, it would be possible to implement `IntoIterator` for `Slice` and specialize `nth()`, but I think it's useful to provide `nth()` on `Slice` itself. It would be nice to implement `Index` for `Slice` instead of `nth()`, but I don't think that's possible because `Index::index()` must return a reference.

I was [planning to include a `len()` method](https://github.com/jturner314/rust-ndarray/commit/4437063697a7670987941b2f278f6ae900d953b6) as part of this PR, but after thinking about it some more, I don't see a good use-case for `len()`.

If you don't think the `nth()` method is sufficiently useful to include in `ndarray`, that's fine too. I just found it useful in my own code and thought I'd propose it.