### PR TITLE
Change SliceInfo::new() to return a Result

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -5,6 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+use error::{ShapeError, ErrorKind};
 use std::ops::{Deref, Range, RangeFrom, RangeFull, RangeTo};
 use std::fmt;
 use std::marker::PhantomData;
@@ -334,16 +335,17 @@ where
 {
     /// Returns a new `SliceInfo` instance.
     ///
-    /// **Panics** if `D` is not consistent with `indices`.
-    pub fn new(indices: T) -> SliceInfo<T, D> {
-        let out_ndim = indices.as_ref().iter().filter(|s| s.is_slice()).count();
+    /// Errors if `D` is not consistent with `indices`.
+    pub fn new(indices: T) -> Result<SliceInfo<T, D>, ShapeError> {
         if let Some(ndim) = D::NDIM {
-            assert_eq!(out_ndim, ndim);
+            if ndim != indices.as_ref().iter().filter(|s| s.is_slice()).count() {
+                return Err(ShapeError::from_kind(ErrorKind::IncompatibleShape));
+            }
         }
-        SliceInfo {
+        Ok(SliceInfo {
             out_dim: PhantomData,
             indices: indices,
-        }
+        })
     }
 }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -120,7 +120,7 @@ fn test_slice_array_dyn() {
         SliceOrIndex::from(1..),
         SliceOrIndex::from(1),
         SliceOrIndex::from(..).step_by(2),
-    ]);
+    ]).unwrap();
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_move(info);
@@ -134,7 +134,7 @@ fn test_slice_dyninput_array_dyn() {
         SliceOrIndex::from(1..),
         SliceOrIndex::from(1),
         SliceOrIndex::from(..).step_by(2),
-    ]);
+    ]).unwrap();
     arr.slice(info);
     arr.slice_mut(info);
     arr.view().slice_move(info);
@@ -148,7 +148,7 @@ fn test_slice_dyninput_vec_fixed() {
         SliceOrIndex::from(1..),
         SliceOrIndex::from(1),
         SliceOrIndex::from(..).step_by(2),
-    ]);
+    ]).unwrap();
     arr.slice(info.as_ref());
     arr.slice_mut(info.as_ref());
     arr.view().slice_move(info.as_ref());
@@ -162,7 +162,7 @@ fn test_slice_dyninput_vec_dyn() {
         SliceOrIndex::from(1..),
         SliceOrIndex::from(1),
         SliceOrIndex::from(..).step_by(2),
-    ]);
+    ]).unwrap();
     arr.slice(info.as_ref());
     arr.slice_mut(info.as_ref());
     arr.view().slice_move(info.as_ref());

--- a/tests/oper.rs
+++ b/tests/oper.rs
@@ -589,7 +589,7 @@ fn scaled_add_3() {
 
                 {
                     let mut av = a.slice_mut(s![..;s1, ..;s2]);
-                    let c = c.slice(SliceInfo::<_, IxDyn>::new(cslice).as_ref());
+                    let c = c.slice(SliceInfo::<_, IxDyn>::new(cslice).unwrap().as_ref());
 
                     let mut answerv = answer.slice_mut(s![..;s1, ..;s2]);
                     answerv += &(beta * &c);


### PR DESCRIPTION
This is a last-minute change for 0.11.0. I think it would be better for `SliceInfo::new()` to return `Err` instead of panicking if `D` is not consistent with `indices`. It's more flexible for the caller and is more similar to `.into_dimensionality()`.

This change doesn't affect #391 and should merge cleanly.

Edit: I initially chose to make `SliceInfo::new()` panic becuase I thought it would be weird for a method named `new()` to return a `Result` instead of the object itself. However, there is precedent for returning a `Result` from `new()`, e.g. [`regex::Regex::new()`](https://docs.rs/regex/0.2.3/regex/struct.Regex.html#method.new).