### PR TITLE
Fix evaluation of arguments in s![]

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -533,67 +533,83 @@ impl<D1: Dimension> SliceNextDim<D1, D1::Larger> for RangeFull {
 macro_rules! s(
     // convert a..b;c into @convert(a..b, c), final item
     (@parse $dim:expr, [$($stack:tt)*] $r:expr;$s:expr) => {
-        {
-            let out_dim = $crate::SliceNextDim::next_dim(&$r, $dim);
-            unsafe {
-                &$crate::SliceInfo::new_unchecked(
-                    [$($stack)* s!(@convert $r, $s)],
-                    out_dim,
-                )
+        match $r {
+            r => {
+                let out_dim = $crate::SliceNextDim::next_dim(&r, $dim);
+                unsafe {
+                    $crate::SliceInfo::new_unchecked(
+                        [$($stack)* s!(@convert r, $s)],
+                        out_dim,
+                    )
+                }
             }
         }
     };
     // convert a..b into @convert(a..b), final item
     (@parse $dim:expr, [$($stack:tt)*] $r:expr) => {
-        {
-            let out_dim = $crate::SliceNextDim::next_dim(&$r, $dim);
-            unsafe {
-                &$crate::SliceInfo::new_unchecked(
-                    [$($stack)* s!(@convert $r)],
-                    out_dim,
-                )
+        match $r {
+            r => {
+                let out_dim = $crate::SliceNextDim::next_dim(&r, $dim);
+                unsafe {
+                    $crate::SliceInfo::new_unchecked(
+                        [$($stack)* s!(@convert r)],
+                        out_dim,
+                    )
+                }
             }
         }
     };
     // convert a..b;c into @convert(a..b, c), final item, trailing comma
     (@parse $dim:expr, [$($stack:tt)*] $r:expr;$s:expr ,) => {
-        {
-            let out_dim = $crate::SliceNextDim::next_dim(&$r, $dim);
-            unsafe {
-                &$crate::SliceInfo::new_unchecked(
-                    [$($stack)* s!(@convert $r, $s)],
-                    out_dim,
-                )
+        match $r {
+            r => {
+                let out_dim = $crate::SliceNextDim::next_dim(&r, $dim);
+                unsafe {
+                    $crate::SliceInfo::new_unchecked(
+                        [$($stack)* s!(@convert r, $s)],
+                        out_dim,
+                    )
+                }
             }
         }
     };
     // convert a..b into @convert(a..b), final item, trailing comma
     (@parse $dim:expr, [$($stack:tt)*] $r:expr ,) => {
-        {
-            let out_dim = $crate::SliceNextDim::next_dim(&$r, $dim);
-            unsafe {
-                &$crate::SliceInfo::new_unchecked(
-                    [$($stack)* s!(@convert $r)],
-                    out_dim,
-                )
+        match $r {
+            r => {
+                let out_dim = $crate::SliceNextDim::next_dim(&r, $dim);
+                unsafe {
+                    $crate::SliceInfo::new_unchecked(
+                        [$($stack)* s!(@convert r)],
+                        out_dim,
+                    )
+                }
             }
         }
     };
     // convert a..b;c into @convert(a..b, c)
     (@parse $dim:expr, [$($stack:tt)*] $r:expr;$s:expr, $($t:tt)*) => {
-        s![@parse
-            $crate::SliceNextDim::next_dim(&$r, $dim),
-            [$($stack)* s!(@convert $r, $s),]
-            $($t)*
-        ]
+        match $r {
+            r => {
+                s![@parse
+                   $crate::SliceNextDim::next_dim(&r, $dim),
+                   [$($stack)* s!(@convert r, $s),]
+                   $($t)*
+                ]
+            }
+        }
     };
     // convert a..b into @convert(a..b)
     (@parse $dim:expr, [$($stack:tt)*] $r:expr, $($t:tt)*) => {
-        s![@parse
-            $crate::SliceNextDim::next_dim(&$r, $dim),
-            [$($stack)* s!(@convert $r),]
-            $($t)*
-        ]
+        match $r {
+            r => {
+                s![@parse
+                   $crate::SliceNextDim::next_dim(&r, $dim),
+                   [$($stack)* s!(@convert r),]
+                   $($t)*
+                ]
+            }
+        }
     };
     // convert range/index into SliceOrIndex
     (@convert $r:expr) => {
@@ -604,6 +620,8 @@ macro_rules! s(
         <$crate::SliceOrIndex as ::std::convert::From<_>>::from($r).step_by($s as isize)
     };
     ($($t:tt)*) => {
-        s![@parse ::std::marker::PhantomData::<$crate::Ix0>, [] $($t)*]
+        // The extra `*&` is a workaround for this compiler bug:
+        // https://github.com/rust-lang/rust/issues/23014
+        &*&s![@parse ::std::marker::PhantomData::<$crate::Ix0>, [] $($t)*]
     };
 );

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -533,38 +533,50 @@ impl<D1: Dimension> SliceNextDim<D1, D1::Larger> for RangeFull {
 macro_rules! s(
     // convert a..b;c into @convert(a..b, c), final item
     (@parse $dim:expr, [$($stack:tt)*] $r:expr;$s:expr) => {
-        unsafe {
-            &$crate::SliceInfo::new_unchecked(
-                [$($stack)* s!(@convert $r, $s)],
-                $crate::SliceNextDim::next_dim(&$r, $dim),
-            )
+        {
+            let out_dim = $crate::SliceNextDim::next_dim(&$r, $dim);
+            unsafe {
+                &$crate::SliceInfo::new_unchecked(
+                    [$($stack)* s!(@convert $r, $s)],
+                    out_dim,
+                )
+            }
         }
     };
     // convert a..b into @convert(a..b), final item
     (@parse $dim:expr, [$($stack:tt)*] $r:expr) => {
-        unsafe {
-            &$crate::SliceInfo::new_unchecked(
-                [$($stack)* s!(@convert $r)],
-                $crate::SliceNextDim::next_dim(&$r, $dim),
-            )
+        {
+            let out_dim = $crate::SliceNextDim::next_dim(&$r, $dim);
+            unsafe {
+                &$crate::SliceInfo::new_unchecked(
+                    [$($stack)* s!(@convert $r)],
+                    out_dim,
+                )
+            }
         }
     };
     // convert a..b;c into @convert(a..b, c), final item, trailing comma
     (@parse $dim:expr, [$($stack:tt)*] $r:expr;$s:expr ,) => {
-        unsafe {
-            &$crate::SliceInfo::new_unchecked(
-                [$($stack)* s!(@convert $r, $s)],
-                $crate::SliceNextDim::next_dim(&$r, $dim),
-            )
+        {
+            let out_dim = $crate::SliceNextDim::next_dim(&$r, $dim);
+            unsafe {
+                &$crate::SliceInfo::new_unchecked(
+                    [$($stack)* s!(@convert $r, $s)],
+                    out_dim,
+                )
+            }
         }
     };
     // convert a..b into @convert(a..b), final item, trailing comma
     (@parse $dim:expr, [$($stack:tt)*] $r:expr ,) => {
-        unsafe {
-            &$crate::SliceInfo::new_unchecked(
-                [$($stack)* s!(@convert $r)],
-                $crate::SliceNextDim::next_dim(&$r, $dim),
-            )
+        {
+            let out_dim = $crate::SliceNextDim::next_dim(&$r, $dim);
+            unsafe {
+                &$crate::SliceInfo::new_unchecked(
+                    [$($stack)* s!(@convert $r)],
+                    out_dim,
+                )
+            }
         }
     };
     // convert a..b;c into @convert(a..b, c)

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -101,6 +101,34 @@ fn test_slice_range_variable() {
 }
 
 #[test]
+fn test_slice_args_eval_range_once() {
+    let mut eval_count = 0;
+    {
+        let mut range = || {
+            eval_count += 1;
+            1..4
+        };
+        let arr = array![0, 1, 2, 3, 4];
+        assert_eq!(arr.slice(s![range()]), array![1, 2, 3]);
+    }
+    assert_eq!(eval_count, 1);
+}
+
+#[test]
+fn test_slice_args_eval_step_once() {
+    let mut eval_count = 0;
+    {
+        let mut step = || {
+            eval_count += 1;
+            -1
+        };
+        let arr = array![0, 1, 2, 3, 4];
+        assert_eq!(arr.slice(s![1..4;step()]), array![3, 2, 1]);
+    }
+    assert_eq!(eval_count, 1);
+}
+
+#[test]
 fn test_slice_array_fixed() {
     let mut arr = Array3::<f64>::zeros((5, 2, 5));
     let info = s![1.., 1, ..;2];

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -94,6 +94,13 @@ fn test_slice_with_many_dim() {
 }
 
 #[test]
+fn test_slice_range_variable() {
+    let range = 1..4;
+    let arr = array![0, 1, 2, 3, 4];
+    assert_eq!(arr.slice(s![range]), array![1, 2, 3]);
+}
+
+#[test]
 fn test_slice_array_fixed() {
     let mut arr = Array3::<f64>::zeros((5, 2, 5));
     let info = s![1.., 1, ..;2];


### PR DESCRIPTION
This PR contains fixes and tests for two issues related to evaluation of arguments in the `s![]` macro. Before, the `$r` expression was used in two places: `SliceNextDim::next_dim` and `s!(@convert ...)`, which caused it to be evaluated twice. In some cases, this also failed the borrow checker.

The fix is to evaluate `$r` only once, binding it to `r`, then determine `out_dim` using `&r`, and then convert `r` to `SliceOrIndex`. Rust's macro hygiene keeps the various `r` bindings from conflicting. The `$s` expression doesn't need to be bound to a variable because it's used only once.