### PR TITLE
Update docs from blas-sys to blas-src

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ your `Cargo.toml`.
 
   - Optional and experimental, compatible with Rust stable
   - Enable transparent BLAS support for matrix multiplication.
-    Uses ``blas-sys`` for pluggable backend, which needs to be configured
+    Uses ``blas-src`` for pluggable backend, which needs to be configured
     separately.
 
 How to use with cargo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //! - `blas`
 //!   - Optional and experimental, compatible with Rust stable
 //!   - Enable transparent BLAS support for matrix multiplication.
-//!     Uses ``blas-sys`` for pluggable backend, which needs to be configured
+//!     Uses ``blas-src`` for pluggable backend, which needs to be configured
 //!     separately.
 //!
 


### PR DESCRIPTION
These places in the docs could also mention `cblas-src`.