### PR TITLE
Add ArcArray and turn RcArray into ArcArray

### DIFF
--- a/src/data_traits.rs
+++ b/src/data_traits.rs
@@ -10,6 +10,7 @@
 
 use std::mem::{self, size_of};
 use std::rc::Rc;
+use std::sync::Arc;
 
 use {
     ArrayBase,
@@ -17,6 +18,7 @@ use {
     ViewRepr,
     OwnedRepr,
     OwnedRcRepr,
+    OwnedArcRepr,
 };
 
 /// Array representation trait.
@@ -118,6 +120,59 @@ unsafe impl<A> DataMut for OwnedRcRepr<A>
 }
 
 unsafe impl<A> DataClone for OwnedRcRepr<A> {
+    unsafe fn clone_with_ptr(&self, ptr: *mut Self::Elem) -> (Self, *mut Self::Elem) {
+        // pointer is preserved
+        (self.clone(), ptr)
+    }
+}
+
+unsafe impl<A> Data for OwnedArcRepr<A> {
+    type Elem = A;
+    fn _data_slice(&self) -> &[A] {
+        &self.0
+    }
+    private_impl!{}
+}
+
+// NOTE: Copy on write
+unsafe impl<A> DataMut for OwnedArcRepr<A>
+    where A: Clone
+{
+    fn ensure_unique<D>(self_: &mut ArrayBase<Self, D>)
+        where Self: Sized,
+              D: Dimension
+    {
+        if Arc::get_mut(&mut self_.data.0).is_some() {
+            return;
+        }
+        if self_.dim.size() <= self_.data.0.len() / 2 {
+            // Create a new vec if the current view is less than half of
+            // backing data.
+            unsafe {
+                *self_ = ArrayBase::from_shape_vec_unchecked(self_.dim.clone(),
+                                                             self_.iter()
+                                                            .cloned()
+                                                            .collect());
+            }
+            return;
+        }
+        let rcvec = &mut self_.data.0;
+        let a_size = mem::size_of::<A>() as isize;
+        let our_off = if a_size != 0 {
+            (self_.ptr as isize - rcvec.as_ptr() as isize) / a_size
+        } else { 0 };
+        let rvec = Arc::make_mut(rcvec);
+        unsafe {
+            self_.ptr = rvec.as_mut_ptr().offset(our_off);
+        }
+    }
+
+    fn is_unique(&mut self) -> bool {
+        Arc::get_mut(&mut self.0).is_some()
+    }
+}
+
+unsafe impl<A> DataClone for OwnedArcRepr<A> {
     unsafe fn clone_with_ptr(&self, ptr: *mut Self::Elem) -> (Self, *mut Self::Elem) {
         // pointer is preserved
         (self.clone(), ptr)
@@ -242,6 +297,29 @@ unsafe impl<A> DataOwned for OwnedRcRepr<A> {
     {
         Self::ensure_unique(&mut self_);
         let data = OwnedRepr(Rc::try_unwrap(self_.data.0).ok().unwrap());
+        ArrayBase {
+            data: data,
+            ptr: self_.ptr,
+            dim: self_.dim,
+            strides: self_.strides,
+        }
+    }
+}
+
+unsafe impl<A> DataOwned for OwnedArcRepr<A> {
+    fn new(elements: Vec<A>) -> Self {
+        OwnedArcRepr(Arc::new(elements))
+    }
+    fn into_shared(self) -> OwnedRcRepr<A> {
+        unimplemented!()
+    }
+    fn into_owned<D>(mut self_: ArrayBase<Self, D>) -> ArrayBase<OwnedRepr<Self::Elem>, D>
+    where
+        A: Clone,
+        D: Dimension,
+    {
+        Self::ensure_unique(&mut self_);
+        let data = OwnedRepr(Arc::try_unwrap(self_.data.0).ok().unwrap());
         ArrayBase {
             data: data,
             ptr: self_.ptr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ extern crate num_complex;
 
 use std::marker::PhantomData;
 use std::rc::Rc;
+use std::sync::Arc;
 
 pub use dimension::{
     Dimension,
@@ -663,6 +664,22 @@ pub struct ArrayBase<S, D>
 /// + [Methods For All Array Types](struct.ArrayBase.html#methods-for-all-array-types)
 pub type RcArray<A, D> = ArrayBase<OwnedRcRepr<A>, D>;
 
+/// An array where the data has shared ownership and is copy on write.
+/// It can act as both an owner as the data as well as a shared reference (view
+/// like).
+///
+/// The `ArcArray<A, D>` is parameterized by `A` for the element type and `D` for
+/// the dimensionality.
+///
+/// [**`ArrayBase`**](struct.ArrayBase.html) is used to implement both the owned
+/// arrays and the views; see its docs for an overview of all array features.  
+///
+/// See also:
+///
+/// + [Constructor Methods for Owned Arrays](struct.ArrayBase.html#constructor-methods-for-owned-arrays)
+/// + [Methods For All Array Types](struct.ArrayBase.html#methods-for-all-array-types)
+pub type ArcArray<A, D> = ArrayBase<OwnedArcRepr<A>, D>;
+
 /// An array that owns its data uniquely.
 ///
 /// `Array` is the main n-dimensional array type, and it owns all its array
@@ -730,12 +747,25 @@ pub struct OwnedRepr<A>(Vec<A>);
 #[derive(Debug)]
 pub struct OwnedRcRepr<A>(Rc<Vec<A>>);
 
-
 impl<A> Clone for OwnedRcRepr<A> {
     fn clone(&self) -> Self {
         OwnedRcRepr(self.0.clone())
     }
 }
+
+/// ArcArray's representation.
+///
+/// *Don’t use this type directly—use the type alias
+/// [`ArcArray`](type.ArcArray.html) for the array type!*
+#[derive(Debug)]
+pub struct OwnedArcRepr<A>(Arc<Vec<A>>);
+
+impl<A> Clone for OwnedArcRepr<A> {
+    fn clone(&self) -> Self {
+        OwnedArcRepr(self.0.clone())
+    }
+}
+
 
 /// Array view’s representation.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,6 +662,7 @@ pub struct ArrayBase<S, D>
 ///
 /// + [Constructor Methods for Owned Arrays](struct.ArrayBase.html#constructor-methods-for-owned-arrays)
 /// + [Methods For All Array Types](struct.ArrayBase.html#methods-for-all-array-types)
+#[deprecated(note="RcArray is replaced by ArcArray")]
 pub type RcArray<A, D> = ArrayBase<OwnedRcRepr<A>, D>;
 
 /// An array where the data has shared ownership and is copy on write.
@@ -744,14 +745,8 @@ pub struct OwnedRepr<A>(Vec<A>);
 ///
 /// *Don’t use this type directly—use the type alias
 /// [`RcArray`](type.RcArray.html) for the array type!*
-#[derive(Debug)]
-pub struct OwnedRcRepr<A>(Rc<Vec<A>>);
-
-impl<A> Clone for OwnedRcRepr<A> {
-    fn clone(&self) -> Self {
-        OwnedRcRepr(self.0.clone())
-    }
-}
+#[deprecated(note="RcArray is replaced by ArcArray")]
+use self::OwnedArcRepr as OwnedRcRepr;
 
 /// ArcArray's representation.
 ///


### PR DESCRIPTION
- ArcArray is like RcArray but using Arc instead, so with thread safe reference
counting. The use case is threading compatible shared ownership of
arrays.
- Remove RcArray; The names remain but they now point to ArcArray.