### PR TITLE
Implement Hash for Dim<I> where Dim<I>: Dimension

### DIFF
--- a/src/dimension/dim.rs
+++ b/src/dimension/dim.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use std::fmt;
+use std::hash;
 use itertools::zip;
 
 use super::IntoDimension;
@@ -66,6 +67,14 @@ impl<I: ?Sized> PartialEq<I> for Dim<I>
 {
     fn eq(&self, rhs: &I) -> bool {
         self.index == *rhs
+    }
+}
+
+impl<I: ?Sized> hash::Hash for Dim<I>
+    where Dim<I>: Dimension,
+{
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.slice().hash(state);
     }
 }
 

--- a/tests/dimension.rs
+++ b/tests/dimension.rs
@@ -10,8 +10,11 @@ use ndarray::{
     Axis,
     Dimension,
     Dim,
+    IxDyn,
     IntoDimension,
 };
+
+use std::hash::{Hash, Hasher};
 
 #[test]
 fn insert_axis()
@@ -211,6 +214,42 @@ fn test_operations() {
 
     y[0] -= 1;
     assert_eq!(y, [0, 1]);
+}
+
+#[test]
+fn test_hash() {
+    fn calc_hash<T: Hash>(value: &T) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+    macro_rules! test_hash_eq {
+        ($arr:expr) => {
+            assert_eq!(calc_hash(&Dim($arr)), calc_hash(&Dim($arr)));
+            assert_eq!(calc_hash(&Dim($arr)), calc_hash(&IxDyn(&$arr)));
+        }
+    }
+    macro_rules! test_hash_ne {
+        ($arr1:expr, $arr2:expr) => {
+            assert_ne!(calc_hash(&Dim($arr1)), calc_hash(&Dim($arr2)));
+            assert_ne!(calc_hash(&Dim($arr1)), calc_hash(&IxDyn(&$arr2)));
+            assert_ne!(calc_hash(&IxDyn(&$arr1)), calc_hash(&Dim($arr2)));
+        }
+    }
+    test_hash_eq!([]);
+    test_hash_eq!([0]);
+    test_hash_eq!([1]);
+    test_hash_eq!([1, 2]);
+    test_hash_eq!([3, 1, 2]);
+    test_hash_eq!([3, 1, 4, 2]);
+    test_hash_eq!([3, 1, 4, 2, 5]);
+    test_hash_eq!([6, 3, 1, 4, 2, 5]);
+    test_hash_ne!([0], [1]);
+    test_hash_ne!([1, 2], [2, 1]);
+    test_hash_ne!([3, 1, 2], [3, 1, 3]);
+    test_hash_ne!([3, 1, 2, 4], [3, 1, 2, 3]);
+    test_hash_ne!([3, 1, 2, 5, 4], [3, 1, 2, 4, 5]);
+    test_hash_ne!([3, 1, 6, 2, 5, 4], [3, 1, 2, 4, 6, 5]);
 }
 
 #[test]


### PR DESCRIPTION
I noticed #408 and thought I'd write a quick implementation. It uses `Dimension::slice()` to easily ensure that equivalent `Ix2` and `IxDyn` hash to the same value, for example. Fwiw, `[T; N]` and `std::vec::Vec` in the standard library use the same hashing strategy (hash a slice of the contents).

cc @Forty-Bot