### PR TITLE
Add ndarray for NumPy users doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,18 @@ matrix:
   include:
     - rust: 1.22.1
       env:
-       - FEATURES='test'
+       - FEATURES='test docs'
     - rust: stable
       env:
-       - FEATURES='test'
+       - FEATURES='test docs'
        - CARGO_INCREMENTAL=0
     - rust: beta
       env:
-       - FEATURES='test'
+       - FEATURES='test docs'
        - CARGO_INCREMENTAL=0
     - rust: nightly
       env:
-       - FEATURES='test'
+       - FEATURES='test docs'
        - IS_NIGHTLY=1
        - CARGO_INCREMENTAL=0
 branches:

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -1,0 +1,1 @@
+//! Standalone documentation pages.

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -1,1 +1,3 @@
 //! Standalone documentation pages.
+
+pub mod ndarray_for_numpy_users;

--- a/src/doc/ndarray_for_numpy_users/coord_transform.rs
+++ b/src/doc/ndarray_for_numpy_users/coord_transform.rs
@@ -1,0 +1,138 @@
+//! Example of rotation with Euler angles.
+//!
+//! This is an example of some coordinate transformations (using Euler angles)
+//! for illustrative purposes. Note that other crates such as
+//! [`cgmath`](https://crates.io/crates/cgmath) or
+//! [`nalgebra`](https://crates.io/crates/nalgebra) may be better-suited if
+//! most of your work is coordinate transformations, since they have built-in
+//! geometry primitives.
+//!
+//! This is the original Python program:
+//!
+//! ```python
+//! # Euler angles (rows) for four coordinate systems (columns).
+//! nelems = 4
+//! bunge = np.ones((3, nelems))
+//!
+//! # Precompute sines and cosines
+//! s1 = np.sin(bunge[0, :])
+//! c1 = np.cos(bunge[0, :])
+//! s2 = np.sin(bunge[1, :])
+//! c2 = np.cos(bunge[1, :])
+//! s3 = np.sin(bunge[2, :])
+//! c3 = np.cos(bunge[2, :])
+//!
+//! # Rotation matrices.
+//! rmat = np.zeros((3, 3, nelems), order='F')
+//! for i in range(nelems):
+//!     rmat[0, 0, i] = c1[i] * c3[i] - s1[i] * s3[i] * c2[i]
+//!     rmat[0, 1, i] = -c1[i] * s3[i] - s1[i] * c2[i] * c3[i]
+//!     rmat[0, 2, i] = s1[i] * s2[i]
+//!
+//!     rmat[1, 0, i] = s1[i] * c3[i] + c1[i] * c2[i] * s3[i]
+//!     rmat[1, 1, i] = -s1[i] * s3[i] + c1[i] * c2[i] * c3[i]
+//!     rmat[1, 2, i] = -c1[i] * s2[i]
+//!
+//!     rmat[2, 0, i] = s2[i] * s3[i]
+//!     rmat[2, 1, i] = s2[i] * c3[i]
+//!     rmat[2, 2, i] = c2[i]
+//!
+//! # Unit vectors of coordinate systems to rotate.
+//! eye2d = np.eye(3)
+//!
+//! # Unit vectors after rotation.
+//! rotated = np.zeros((3, 3, nelems), order='F')
+//! for i in range(nelems):
+//!     rotated[:,:,i] = rmat[:,:,i].dot(eye2d)
+//! ```
+//!
+//! This is a direct translation to `ndarray`:
+//!
+//! ```
+//! #[macro_use]
+//! extern crate ndarray;
+//!
+//! use ndarray::prelude::*;
+//!
+//! fn main() {
+//!     let nelems = 4;
+//!     let bunge = Array::ones((3, nelems));
+//!
+//!     let s1 = bunge.slice(s![0, ..]).mapv(f64::sin);
+//!     let c1 = bunge.slice(s![0, ..]).mapv(f64::cos);
+//!     let s2 = bunge.slice(s![1, ..]).mapv(f64::sin);
+//!     let c2 = bunge.slice(s![1, ..]).mapv(f64::cos);
+//!     let s3 = bunge.slice(s![2, ..]).mapv(f64::sin);
+//!     let c3 = bunge.slice(s![2, ..]).mapv(f64::cos);
+//!
+//!     let mut rmat = Array::zeros((3, 3, nelems).f());
+//!     for i in 0..nelems {
+//!         rmat[[0, 0, i]] = c1[i] * c3[i] - s1[i] * s3[i] * c2[i];
+//!         rmat[[0, 1, i]] = -c1[i] * s3[i] - s1[i] * c2[i] * c3[i];
+//!         rmat[[0, 2, i]] = s1[i] * s2[i];
+//!
+//!         rmat[[1, 0, i]] = s1[i] * c3[i] + c1[i] * c2[i] * s3[i];
+//!         rmat[[1, 1, i]] = -s1[i] * s3[i] + c1[i] * c2[i] * c3[i];
+//!         rmat[[1, 2, i]] = -c1[i] * s2[i];
+//!
+//!         rmat[[2, 0, i]] = s2[i] * s3[i];
+//!         rmat[[2, 1, i]] = s2[i] * c3[i];
+//!         rmat[[2, 2, i]] = c2[i];
+//!     }
+//!
+//!     let eye2d = Array::eye(3);
+//!
+//!     let mut rotated = Array::zeros((3, 3, nelems).f());
+//!     for i in 0..nelems {
+//!         rotated
+//!             .slice_mut(s![.., .., i])
+//!             .assign({ &rmat.slice(s![.., .., i]).dot(&eye2d) });
+//!     }
+//! }
+//! ```
+//!
+//! Instead of looping over indices, a cleaner (and usually faster) option is
+//! to zip arrays together. It's also possible to avoid some of the temporary
+//! memory allocations in the original program. The improved version looks like
+//! this:
+//!
+//! ```
+//! #[macro_use]
+//! extern crate ndarray;
+//!
+//! use ndarray::prelude::*;
+//!
+//! fn main() {
+//!     let nelems = 4;
+//!     let bunge = Array2::<f64>::ones((3, nelems));
+//!
+//!     let mut rmat = Array::zeros((3, 3, nelems).f());
+//!     azip!(mut rmat (rmat.axis_iter_mut(Axis(2))), ref bunge (bunge.axis_iter(Axis(1))) in {
+//!         let s1 = bunge[0].sin();
+//!         let c1 = bunge[0].cos();
+//!         let s2 = bunge[1].sin();
+//!         let c2 = bunge[1].cos();
+//!         let s3 = bunge[2].sin();
+//!         let c3 = bunge[2].cos();
+//!
+//!         rmat[[0, 0]] = c1 * c3 - s1 * s3 * c2;
+//!         rmat[[0, 1]] = -c1 * s3 - s1 * c2 * c3;
+//!         rmat[[0, 2]] = s1 * s2;
+//!
+//!         rmat[[1, 0]] = s1 * c3 + c1 * c2 * s3;
+//!         rmat[[1, 1]] = -s1 * s3 + c1 * c2 * c3;
+//!         rmat[[1, 2]] = -c1 * s2;
+//!
+//!         rmat[[2, 0]] = s2 * s3;
+//!         rmat[[2, 1]] = s2 * c3;
+//!         rmat[[2, 2]] = c2;
+//!     });
+//!
+//!     let eye2d = Array2::<f64>::eye(3);
+//!
+//!     let mut rotated = Array3::<f64>::zeros((3, 3, nelems).f());
+//!     azip!(mut rotated (rotated.axis_iter_mut(Axis(2)), rmat (rmat.axis_iter(Axis(2)))) in {
+//!         rotated.assign({ &rmat.dot(&eye2d) });
+//!     });
+//! }
+//! ```

--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -610,3 +610,5 @@
 //! [Zip]: ../../struct.Zip.html
 
 pub mod rk_step;
+pub mod coord_transform;
+pub mod simple_math;

--- a/src/doc/ndarray_for_numpy_users/mod.rs
+++ b/src/doc/ndarray_for_numpy_users/mod.rs
@@ -1,0 +1,612 @@
+//! `ndarray` for NumPy users.
+//!
+//! This is an introductory guide to `ndarray` for people with experience using
+//! NumPy, although it may also be useful to others. For a more general
+//! introduction to `ndarray`'s array type `ArrayBase`, see the [`ArrayBase`
+//! docs][ArrayBase].
+//!
+//! # Contents
+//!
+//! * [Similarities](#similarities)
+//! * [Some key differences](#some-key-differences)
+//! * [Other Rust array/matrix crates](#other-rust-arraymatrix-crates)
+//! * [Rough `ndarray`–NumPy equivalents](#rough-ndarraynumpy-equivalents)
+//!
+//!   * [Array creation](#array-creation)
+//!   * [Indexing and slicing](#indexing-and-slicing)
+//!   * [Shape and strides](#shape-and-strides)
+//!   * [Mathematics](#mathematics)
+//!   * [Array manipulation](#array-manipulation)
+//!   * [Iteration](#iteration)
+//!   * [Convenience methods for 2-D arrays](#convenience-methods-for-2-d-arrays)
+//!
+//! # Similarities
+//!
+//! `ndarray`'s array type ([`ArrayBase`][ArrayBase]), is very similar to
+//! NumPy's array type (`numpy.ndarray`):
+//!
+//! * Arrays have a single element type.
+//! * Arrays can have arbitrarily many dimensions.
+//! * Arrays can have arbitrary strides.
+//! * Indexing starts at zero, not one.
+//! * The default memory layout is row-major, and the default iterators follow
+//!   row-major order (also called "logical order" in the documentation).
+//! * Arithmetic operators work elementwise. (For example, `a * b` performs
+//!   elementwise multiplication, not matrix multiplication.)
+//! * Owned arrays are contiguous in memory.
+//! * Many operations, such as slicing, are very cheap because they can return
+//!   a view of an array instead of copying the data.
+//!
+//! NumPy has many features that `ndarray` doesn't have yet, such as:
+//!
+//! * [index arrays](https://docs.scipy.org/doc/numpy/user/basics.indexing.html#index-arrays)
+//! * [mask index arrays](https://docs.scipy.org/doc/numpy/user/basics.indexing.html#boolean-or-mask-index-arrays)
+//! * co-broadcasting (`ndarray` only supports broadcasting the right-hand array in a binary operation.)
+//!
+//! # Some key differences
+//!
+//! <table>
+//! <tr>
+//! <th>
+//!
+//! NumPy
+//!
+//! </th>
+//! <th>
+//!
+//! `ndarray`
+//!
+//! </th>
+//! </tr>
+//!
+//! <tr>
+//! <td>
+//!
+//! In NumPy, there is no distinction between owned arrays, views, and mutable
+//! views. There can be multiple arrays (instances of `numpy.ndarray`) that
+//! mutably reference the same data.
+//!
+//! </td>
+//! <td>
+//!
+//! In `ndarray`, all arrays are instances of [`ArrayBase`][ArrayBase], but
+//! `ArrayBase` is generic over the ownership of the data. [`Array`][Array]
+//! owns its data; [`ArrayView`][ArrayView] is a view;
+//! [`ArrayViewMut`][ArrayViewMut] is a mutable view; and
+//! [`ArcArray`][ArcArray] has a reference-counted pointer to its data (with
+//! copy-on-write mutation). Arrays and views follow Rust's aliasing rules.
+//!
+//! </td>
+//! </tr>
+//!
+//! <tr>
+//! <td>
+//!
+//! In NumPy, all arrays are dynamic-dimensional.
+//!
+//! </td>
+//! <td>
+//!
+//! In `ndarray`, you can create fixed-dimension arrays, such as
+//! [`Array2`][Array2]. This takes advantage of the type system to help you
+//! write correct code and also avoids small heap allocations for the shape and
+//! strides.
+//!
+//! </td>
+//! </tr>
+//!
+//! <tr>
+//! <td>
+//!
+//! When slicing in NumPy, the indices are `start`, `start + step`, `start +
+//! 2*step`, … until reaching `end` (exclusive).
+//!
+//! </td>
+//! <td>
+//!
+//! When slicing in `ndarray`, the axis is first sliced with `start..end`. Then if
+//! `step` is positive, the first index is the front of the slice; if `step` is
+//! negative, the first index is the back of the slice. This means that the
+//! behavior is the same as NumPy except when `step < -1`. See the docs for the
+//! [`s![]` macro][s!] for more details.
+//!
+//! </td>
+//! </tr>
+//! </table>
+//!
+//! # Other Rust array/matrix crates
+//!
+//! Of the array/matrix types in Rust crates, the `ndarray` array type is probably
+//! the most similar to NumPy's arrays and is the most flexible. However, if your
+//! use-case is constrained to linear algebra on 1-D and 2-D vectors and matrices,
+//! it might be worth considering other crates:
+//!
+//! * [`nalgebra`](https://crates.io/crates/nalgebra) provides 1-D and 2-D
+//!   column-major vector and matrix types for linear algebra. Vectors and matrices
+//!   can have constant or dynamic shapes, and `nalgebra` uses the type system to
+//!   provide compile-time checking of shapes, not just the number of dimensions.
+//!   `nalgebra` provides convenient functionality for geometry (e.g. coordinate
+//!   transformations) and linear algebra.
+//! * [`cgmath`](https://crates.io/crates/cgmath) provides 1-D and 2-D column-major
+//!   types of shape 4×4 or smaller. It's primarily designed for computer graphics
+//!   and provides convenient functionality for geometry (e.g. coordinate
+//!   transformations). Similar to `nalgebra`, `cgmath` uses the type system to
+//!   provide compile-time checking of shapes.
+//! * [`rulinalg`](https://crates.io/crates/rulinalg) provides 1-D and 2-D
+//!   row-major vector and matrix types with dynamic shapes. Similar to `ndarray`,
+//!   `rulinalg` provides compile-time checking of the number of dimensions, but
+//!   not shapes. `rulinalg` provides pure-Rust implementations of linear algebra
+//!   operations.
+//! * If there's another crate that should be listed here, please let us know.
+//!
+//! In contrast to these crates, `ndarray` provides an *n*-dimensional array type,
+//! so it's not restricted to 1-D and 2-D vectors and matrices. Also, operators
+//! operate elementwise by default, so the multiplication operator `*` performs
+//! elementwise multiplication instead of matrix multiplication. (You have to
+//! specifically call `.dot()` if you want matrix multiplication.) Linear algebra
+//! with `ndarray` is provided by other crates, e.g.
+//! [`ndarray-linalg`](https://crates.io/crates/ndarray-linalg) and
+//! [`linxal`](https://crates.io/crates/linxal).
+//!
+//! # Rough `ndarray`–NumPy equivalents
+//!
+//! These tables provide some rough equivalents of NumPy operations in `ndarray`.
+//! There are a variety of other methods that aren't included in these tables,
+//! including shape-manipulation, array creation, and iteration routines.
+//!
+//! It's assumed that you've imported NumPy like this:
+//!
+//! ```python
+//! import numpy as np
+//! ```
+//!
+//! and `ndarray` like this:
+//!
+//! ```
+//! #[macro_use]
+//! extern crate ndarray;
+//!
+//! use ndarray::prelude::*;
+//! #
+//! # fn main() {}
+//! ```
+//!
+//! ## Array creation
+//!
+//! This table contains ways to create arrays from scratch. For creating arrays by
+//! operations on other arrays (e.g. arithmetic), see the other tables. Also see
+//! the [`::from_vec()`][::from_vec()], [`::from_iter()`][::from_iter()],
+//! [`::default()`][::default()], [`::from_shape_fn()`][::from_shape_fn()], and
+//! [`::from_shape_vec_unchecked()`][::from_shape_vec_unchecked()] methods.
+//!
+//! NumPy | `ndarray` | Notes
+//! ------|-----------|------
+//! `np.array([[1.,2.,3.], [4.,5.,6.]])` | [`array![[1.,2.,3.], [4.,5.,6.]]`][array!] or [`arr2(&[[1.,2.,3.], [4.,5.,6.]])`][arr2()] | 2×3 floating-point array literal
+//! `np.arange(0., 10., 0.5)` or `np.r_[:10.:0.5]` | [`Array::range(0., 10., 0.5)`][::range()] | create a 1-D array with values `0.`, `0.5`, …, `9.5`
+//! `np.linspace(0., 10., 11)` or `np.r_[:10.:11j]` | [`Array::linspace(0., 10., 11)`][::linspace()] | create a 1-D array with 11 elements with values `0.`, …, `10.`
+//! `np.ones((3, 4, 5))` | [`Array::ones((3, 4, 5))`][::ones()] | create a 3×4×5 array filled with ones (inferring the element type)
+//! `np.zeros((3, 4, 5))` | [`Array::zeros((3, 4, 5))`][::zeros()] | create a 3×4×5 array filled with zeros (inferring the element type)
+//! `np.zeros((3, 4, 5), order='F')` | [`Array::zeros((3, 4, 5).f())`][::zeros()] | create a 3×4×5 array with Fortran (column-major) memory layout filled with zeros (inferring the element type)
+//! `np.zeros_like(a, order='C')` | [`Array::zeros(a.raw_dim())`][::zeros()] | create an array of zeros of the shape shape as `a`, with row-major memory layout (unlike NumPy, this infers the element type from context instead of duplicating `a`'s element type)
+//! `np.full((3, 4), 7.)` | [`Array::from_elem((3, 4), 7.)`][::from_elem()] | create a 3×4 array filled with the value `7.`
+//! `np.eye(3)` | [`Array::eye(3)`][::eye()] | create a 3×3 identity matrix (inferring the element type)
+//! `np.array([1, 2, 3, 4]).reshape((2, 2))` | [`Array::from_shape_vec((2, 2), vec![1, 2, 3, 4])?`][::from_shape_vec()] | create a 2×2 array from the elements in the list/`Vec`
+//! `np.array([1, 2, 3, 4]).reshape((2, 2), order='F')` | [`Array::from_shape_vec((2, 2).f(), vec![1, 2, 3, 4])?`][::from_shape_vec()] | create a 2×2 array from the elements in the list/`Vec` using Fortran (column-major) order
+//! `np.random` | See the [`ndarray-rand`](https://crates.io/crates/ndarray-rand) crate. | create arrays of random numbers
+//!
+//! ## Indexing and slicing
+//!
+//! A few notes:
+//!
+//! * Indices start at 0. For example, "row 1" is the second row in the array.
+//!
+//! * Some methods have multiple variants in terms of ownership and mutability.
+//!   Only the non-mutable methods that take the array by reference are listed in
+//!   this table. For example, [`.slice()`][.slice()] also has corresponding
+//!   methods [`.slice_mut()`][.slice_mut()], [`.slice_move()`][.slice_move()], and
+//!   [`.slice_inplace()`][.slice_inplace()].
+//!
+//! * The behavior of slicing is slightly different from NumPy for slices with
+//!   `step < -1`. See the docs for the [`s![]` macro][s!] for more details.
+//!
+//! NumPy | `ndarray` | Notes
+//! ------|-----------|------
+//! `a[-1]` | [`a[a.len() - 1]`][.index()] | access the last element in 1-D array `a`
+//! `a[1, 4]` | [`a[[1, 4]]`][.index()] | access the element in row 1, column 4
+//! `a[1]` or `a[1, :, :]` | [`a.slice(s![1, .., ..])`][.slice()] or [`a.subview(Axis(0), 1)`][.subview()] | get a 2-D subview of a 3-D array at index 1 of axis 0
+//! `a[0:5]` or `a[:5]` or `a[0:5, :]` | [`a.slice(s![0..5, ..])`][.slice()] or [`a.slice(s![..5, ..])`][.slice()] or [`a.slice_axis(Axis(0), Slice::from(0..5))`][.slice_axis()] | get the first 5 rows of a 2-D array
+//! `a[-5:]` or `a[-5:, :]` | [`a.slice(s![-5.., ..])`][.slice()] or [`a.slice_axis(Axis(0), Slice::from(-5..))`][.slice_axis()] | get the last 5 rows of a 2-D array
+//! `a[:3, 4:9]` | [`a.slice(s![..3, 4..9])`][.slice()] | columns 4, 5, 6, 7, and 8 of the first 3 rows
+//! `a[1:4:2, ::-1]` | [`a.slice(s![1..4;2, ..;-1])`][.slice()] | rows 1 and 3 with the columns in reverse order
+//!
+//! ## Shape and strides
+//!
+//! Note that [`a.shape()`][.shape()], [`a.dim()`][.dim()], and
+//! [`a.raw_dim()`][.raw_dim()] all return the shape of the array, but as
+//! different types. `a.shape()` returns the shape as `&[Ix]`, (where
+//! [`Ix`][Ix] is `usize`) which is useful for general operations on the shape.
+//! `a.dim()` returns the shape as `D::Pattern`, which is useful for
+//! pattern-matching shapes. `a.raw_dim()` returns the shape as `D`, which is
+//! useful for creating other arrays of the same shape.
+//!
+//! NumPy | `ndarray` | Notes
+//! ------|-----------|------
+//! `np.ndim(a)` or `a.ndim` | [`a.ndim()`][.ndim()] | get the number of dimensions of array `a`
+//! `np.size(a)` or `a.size` | [`a.len()`][.len()] | get the number of elements in array `a`
+//! `np.shape(a)` or `a.shape` | [`a.shape()`][.shape()] or [`a.dim()`][.dim()] | get the shape of array `a`
+//! `a.shape[axis]` | [`a.len_of(Axis(axis))`][.len_of()] | get the length of an axis
+//! `a.strides` | [`a.strides()`][.strides()] | get the strides of array `a`
+//! `np.size(a) == 0` or `a.size == 0` | [`a.is_empty()`][.is_empty()] | check if the array has zero elements
+//!
+//! ## Mathematics
+//!
+//! Note that [`.mapv()`][.mapv()] has corresponding methods [`.map()`][.map()],
+//! [`.mapv_into()`][.mapv_into()], [`.map_inplace()`][.map_inplace()], and
+//! [`.mapv_inplace()`][.mapv_inplace()]. Also look at [`.fold()`][.fold()],
+//! [`.visit()`][.visit()], [`.fold_axis()`][.fold_axis()], and
+//! [`.map_axis()`][.map_axis()].
+//!
+//! <table>
+//! <tr><th>
+//!
+//! NumPy
+//!
+//! </th><th>
+//!
+//! `ndarray`
+//!
+//! </th><th>
+//!
+//! Notes
+//!
+//! </th></tr>
+//!
+//! <tr><td>
+//!
+//! `a.transpose()` or `a.T`
+//!
+//! </td><td>
+//!
+//! [`a.t()`][.t()] or [`a.reversed_axes()`][.reversed_axes()]
+//!
+//! </td><td>
+//!
+//! transpose of array `a` (view for `.t()` or by-move for `.reversed_axes()`)
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `mat1.dot(mat2)`
+//!
+//! </td><td>
+//!
+//! [`mat1.dot(&mat2)`][matrix-* dot]
+//!
+//! </td><td>
+//!
+//! 2-D matrix multiply
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `mat.dot(vec)`
+//!
+//! </td><td>
+//!
+//! [`mat.dot(&vec)`][matrix-* dot]
+//!
+//! </td><td>
+//!
+//! 2-D matrix dot 1-D column vector
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `vec.dot(mat)`
+//!
+//! </td><td>
+//!
+//! [`vec.dot(&mat)`][vec-* dot]
+//!
+//! </td><td>
+//!
+//! 1-D row vector dot 2-D matrix
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `vec1.dot(vec2)`
+//!
+//! </td><td>
+//!
+//! [`vec1.dot(&vec2)`][vec-* dot]
+//!
+//! </td><td>
+//!
+//! vector dot product
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `a * b`, `a + b`, etc.
+//!
+//! </td><td>
+//!
+//! [`a * b`, `a + b`, etc.](../../struct.ArrayBase.html#arithmetic-operations)
+//!
+//! </td><td>
+//!
+//! element-wise arithmetic operations
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `a**3`
+//!
+//! </td><td>
+//!
+//! [`a.mapv(|a| a.powi(3))`][.mapv()]
+//!
+//! </td><td>
+//!
+//! element-wise power of 3
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `np.sqrt(a)`
+//!
+//! </td><td>
+//!
+//! [`a.mapv(f64::sqrt)`][.mapv()]
+//!
+//! </td><td>
+//!
+//! element-wise square root for `f64` array
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `(a>0.5)`
+//!
+//! </td><td>
+//!
+//! [`a.mapv(|a| a > 0.5)`][.mapv()]
+//!
+//! </td><td>
+//!
+//! array of `bool`s of same shape as `a` with `true` where `a > 0.5` and `false` elsewhere
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `np.sum(a)` or `a.sum()`
+//!
+//! </td><td>
+//!
+//! [`a.scalar_sum()`][.scalar_sum()]
+//!
+//! </td><td>
+//!
+//! sum the elements in `a`
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `np.sum(a, axis=2)` or `a.sum(axis=2)`
+//!
+//! </td><td>
+//!
+//! [`a.sum_axis(Axis(2))`][.sum_axis()]
+//!
+//! </td><td>
+//!
+//! sum the elements in `a` along axis 2
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `np.mean(a)` or `a.mean()`
+//!
+//! </td><td>
+//!
+//! `a.scalar_sum() / a.len() as f64`
+//!
+//! </td><td>
+//!
+//! calculate the mean of the elements in `f64` array `a`
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `np.mean(a, axis=2)` or `a.mean(axis=2)`
+//!
+//! </td><td>
+//!
+//! [`a.mean_axis(Axis(2))`][.mean_axis()]
+//!
+//! </td><td>
+//!
+//! calculate the mean of the elements in `a` along axis 2
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `np.allclose(a, b, atol=1e-8)`
+//!
+//! </td><td>
+//!
+//! [`a.all_close(&b, 1e-8)`][.all_close()]
+//!
+//! </td><td>
+//!
+//! check if the arrays' elementwise differences are within an absolute tolerance
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `np.diag(a)`
+//!
+//! </td><td>
+//!
+//! [`a.diag()`][.diag()]
+//!
+//! </td><td>
+//!
+//! view the diagonal of `a`
+//!
+//! </td></tr>
+//!
+//! <tr><td>
+//!
+//! `np.linalg`
+//!
+//! </td><td>
+//!
+//! See other crates, e.g.
+//! [`ndarray-linalg`](https://crates.io/crates/ndarray-linalg) and
+//! [`linxal`](https://crates.io/crates/linxal).
+//!
+//! </td><td>
+//!
+//! linear algebra (matrix inverse, solving, decompositions, etc.)
+//!
+//! </td></tr>
+//! </table>
+//!
+//! ## Array manipulation
+//!
+//! NumPy | `ndarray` | Notes
+//! ------|-----------|------
+//! `a[:] = 3.` | [`a.fill(3.)`][.fill()] | set all array elements to the same scalar value
+//! `a[:] = b` | [`a.assign(&b)`][.assign()] | copy the data from array `b` into array `a`
+//! `np.concatenate((a,b), axis=1)` | [`stack![Axis(1), a, b]`][stack!] or [`stack(Axis(1), &[a.view(), b.view()])`][stack()] | concatenate arrays `a` and `b` along axis 1
+//! `a[:,np.newaxis]` or `np.expand_dims(a, axis=1)` | [`a.insert_axis(Axis(1))`][.insert_axis()] | create an array from `a`, inserting a new axis 1
+//! `a.transpose()` or `a.T` | [`a.t()`][.t()] or [`a.reversed_axes()`][.reversed_axes()] | transpose of array `a` (view for `.t()` or by-move for `.reversed_axes()`)
+//! `np.diag(a)` | [`a.diag()`][.diag()] | view the diagonal of `a`
+//! `a.flatten()` | [`Array::from_iter(a.iter())`][::from_iter()] | create a 1-D array by flattening `a`
+//!
+//! ## Iteration
+//!
+//! `ndarray` has lots of interesting iterators/producers that implement the
+//! [`NdProducer`][NdProducer] trait, which is a generalization of `Iterator`
+//! to multiple dimensions. This makes it possible to correctly and efficiently
+//! zip together slices/subviews of arrays in multiple dimensions with
+//! [`Zip`][Zip] or [`azip!()`][azip!]. The purpose of this is similar to
+//! [`np.nditer`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.nditer.html),
+//! but [`Zip`][Zip] is implemented and used somewhat differently.
+//!
+//! This table lists some of the iterators/producers which have a direct
+//! equivalent in NumPy. For a more complete introduction to producers and
+//! iterators, see [*Loops, Producers, and
+//! Iterators*](../../struct.ArrayBase.html#loops-producers-and-iterators).
+//! Note that there are also variants of these iterators (with a `_mut` suffix)
+//! that yield `ArrayViewMut` instead of `ArrayView`.
+//!
+//! NumPy | `ndarray` | Notes
+//! ------|-----------|------
+//! `a.flat` | [`a.iter()`][.iter()] | iterator over the array elements in logical order
+//! `np.ndenumerate(a)` | [`a.indexed_iter()`][.indexed_iter()] | flat iterator yielding the index along with each element reference
+//! `iter(a)` | [`a.outer_iter()`][.outer_iter()] or [`a.axis_iter(Axis(0))`][.axis_iter()] | iterator over the first (outermost) axis, yielding each subview
+//!
+//! ## Convenience methods for 2-D arrays
+//!
+//! NumPy | `ndarray` | Notes
+//! ------|-----------|------
+//! `len(a)` or `a.shape[0]` | [`a.rows()`][.rows()] | get the number of rows in a 2-D array
+//! `a.shape[1]` | [`a.cols()`][.cols()] | get the number of columns in a 2-D array
+//! `a[1]` or `a[1,:]` | [`a.row(1)`][.row()] or [`a.row_mut(1)`][.row_mut()] | view (or mutable view) of row 1 in a 2-D array
+//! `a[:,4]` | [`a.column(4)`][.column()] or [`a.column_mut(4)`][.column_mut()] | view (or mutable view) of column 4 in a 2-D array
+//! `a.shape[0] == a.shape[1]` | [`a.is_square()`][.is_square()] | check if the array is square
+//!
+//! [.all_close()]: ../../struct.ArrayBase.html#method.all_close
+//! [ArcArray]: ../../type.ArcArray.html
+//! [arr2()]: ../../fn.arr2.html
+//! [array!]: ../../macro.array.html
+//! [Array]: ../../type.Array.html
+//! [Array2]: ../../type.Array2.html
+//! [ArrayBase]: ../../struct.ArrayBase.html
+//! [ArrayView]: ../../type.ArrayView.html
+//! [ArrayViewMut]: ../../type.ArrayViewMut.html
+//! [.assign()]: ../../struct.ArrayBase.html#method.assign
+//! [.axis_iter()]: ../../struct.ArrayBase.html#method.axis_iter
+//! [azip!]: ../../macro.azip.html
+//! [.cols()]: ../../struct.ArrayBase.html#method.cols
+//! [.column()]: ../../struct.ArrayBase.html#method.column
+//! [.column_mut()]: ../../struct.ArrayBase.html#method.column_mut
+//! [::default()]: ../../struct.ArrayBase.html#method.default
+//! [.diag()]: ../../struct.ArrayBase.html#method.diag
+//! [.dim()]: ../../struct.ArrayBase.html#method.dim
+//! [::eye()]: ../../struct.ArrayBase.html#method.eye
+//! [.fill()]: ../../struct.ArrayBase.html#method.fill
+//! [.fold()]: ../../struct.ArrayBase.html#method.fold
+//! [.fold_axis()]: ../../struct.ArrayBase.html#method.fold_axis
+//! [::from_elem()]: ../../struct.ArrayBase.html#method.from_elem
+//! [::from_iter()]: ../../struct.ArrayBase.html#method.from_iter
+//! [::from_shape_fn()]: ../../struct.ArrayBase.html#method.from_shape_fn
+//! [::from_shape_vec()]: ../../struct.ArrayBase.html#method.from_shape_vec
+//! [::from_shape_vec_unchecked()]: ../../struct.ArrayBase.html#method.from_shape_vec_unchecked
+//! [::from_vec()]: ../../struct.ArrayBase.html#method.from_vec
+//! [.index()]: ../../struct.ArrayBase.html#impl-Index<I>
+//! [.indexed_iter()]: ../../struct.ArrayBase.html#method.indexed_iter
+//! [.insert_axis()]: ../../struct.ArrayBase.html#method.insert_axis
+//! [.is_empty()]: ../../struct.ArrayBase.html#method.is_empty
+//! [.is_square()]: ../../struct.ArrayBase.html#method.is_square
+//! [.iter()]: ../../struct.ArrayBase.html#method.iter
+//! [Ix]: ../../type.Ix.html
+//! [.len()]: ../../struct.ArrayBase.html#method.len
+//! [.len_of()]: ../../struct.ArrayBase.html#method.len_of
+//! [::linspace()]: ../../struct.ArrayBase.html#method.linspace
+//! [.map()]: ../../struct.ArrayBase.html#method.map
+//! [.map_axis()]: ../../struct.ArrayBase.html#method.map_axis
+//! [.map_inplace()]: ../../struct.ArrayBase.html#method.map_inplace
+//! [.mapv()]: ../../struct.ArrayBase.html#method.mapv
+//! [.mapv_inplace()]: ../../struct.ArrayBase.html#method.mapv_inplace
+//! [.mapv_into()]: ../../struct.ArrayBase.html#method.mapv_into
+//! [matrix-* dot]: ../../struct.ArrayBase.html#method.dot-1
+//! [.mean_axis()]: ../../struct.ArrayBase.html#method.mean_axis
+//! [.ndim()]: ../../struct.ArrayBase.html#method.ndim
+//! [NdProducer]: ../../trait.NdProducer.html
+//! [::ones()]: ../../struct.ArrayBase.html#method.ones
+//! [.outer_iter()]: ../../struct.ArrayBase.html#method.outer_iter
+//! [::range()]: ../../struct.ArrayBase.html#method.range
+//! [.raw_dim()]: ../../struct.ArrayBase.html#method.raw_dim
+//! [.reversed_axes()]: ../../struct.ArrayBase.html#method.reversed_axes
+//! [.row()]: ../../struct.ArrayBase.html#method.row
+//! [.row_mut()]: ../../struct.ArrayBase.html#method.row_mut
+//! [.rows()]: ../../struct.ArrayBase.html#method.rows
+//! [s!]: ../../macro.s.html
+//! [.scalar_sum()]: ../../struct.ArrayBase.html#method.scalar_sum
+//! [.slice()]: ../../struct.ArrayBase.html#method.slice
+//! [.slice_axis()]: ../../struct.ArrayBase.html#method.slice_axis
+//! [.slice_inplace()]: ../../struct.ArrayBase.html#method.slice_inplace
+//! [.slice_move()]: ../../struct.ArrayBase.html#method.slice_move
+//! [.slice_mut()]: ../../struct.ArrayBase.html#method.slice_mut
+//! [.shape()]: ../../struct.ArrayBase.html#method.shape
+//! [stack!]: ../../macro.stack.html
+//! [stack()]: ../../fn.stack.html
+//! [.strides()]: ../../struct.ArrayBase.html#method.strides
+//! [.subview()]: ../../struct.ArrayBase.html#method.subview
+//! [.sum_axis()]: ../../struct.ArrayBase.html#method.sum_axis
+//! [.t()]: ../../struct.ArrayBase.html#method.t
+//! [::uninitialized()]: ../../struct.ArrayBase.html#method.uninitialized
+//! [vec-* dot]: ../../struct.ArrayBase.html#method.dot
+//! [.visit()]: ../../struct.ArrayBase.html#method.visit
+//! [::zeros()]: ../../struct.ArrayBase.html#method.zeros
+//! [Zip]: ../../struct.Zip.html
+
+pub mod rk_step;

--- a/src/doc/ndarray_for_numpy_users/rk_step.rs
+++ b/src/doc/ndarray_for_numpy_users/rk_step.rs
@@ -1,0 +1,214 @@
+//! Example of translating `rk_step` function from SciPy.
+//!
+//! This snippet is a [selection of lines from
+//! `rk.py`](https://github.com/scipy/scipy/blob/v1.0.0/scipy/integrate/_ivp/rk.py#L2-L78).
+//! See the [license for this snippet](#scipy-license).
+//!
+//! ```python
+//! import numpy as np
+//!
+//! def rk_step(fun, t, y, f, h, A, B, C, E, K):
+//!     """Perform a single Runge-Kutta step.
+//!     This function computes a prediction of an explicit Runge-Kutta method and
+//!     also estimates the error of a less accurate method.
+//!     Notation for Butcher tableau is as in [1]_.
+//!     Parameters
+//!     ----------
+//!     fun : callable
+//!         Right-hand side of the system.
+//!     t : float
+//!         Current time.
+//!     y : ndarray, shape (n,)
+//!         Current state.
+//!     f : ndarray, shape (n,)
+//!         Current value of the derivative, i.e. ``fun(x, y)``.
+//!     h : float
+//!         Step to use.
+//!     A : list of ndarray, length n_stages - 1
+//!         Coefficients for combining previous RK stages to compute the next
+//!         stage. For explicit methods the coefficients above the main diagonal
+//!         are zeros, so `A` is stored as a list of arrays of increasing lengths.
+//!         The first stage is always just `f`, thus no coefficients for it
+//!         are required.
+//!     B : ndarray, shape (n_stages,)
+//!         Coefficients for combining RK stages for computing the final
+//!         prediction.
+//!     C : ndarray, shape (n_stages - 1,)
+//!         Coefficients for incrementing time for consecutive RK stages.
+//!         The value for the first stage is always zero, thus it is not stored.
+//!     E : ndarray, shape (n_stages + 1,)
+//!         Coefficients for estimating the error of a less accurate method. They
+//!         are computed as the difference between b's in an extended tableau.
+//!     K : ndarray, shape (n_stages + 1, n)
+//!         Storage array for putting RK stages here. Stages are stored in rows.
+//!     Returns
+//!     -------
+//!     y_new : ndarray, shape (n,)
+//!         Solution at t + h computed with a higher accuracy.
+//!     f_new : ndarray, shape (n,)
+//!         Derivative ``fun(t + h, y_new)``.
+//!     error : ndarray, shape (n,)
+//!         Error estimate of a less accurate method.
+//!     References
+//!     ----------
+//!     .. [1] E. Hairer, S. P. Norsett G. Wanner, "Solving Ordinary Differential
+//!            Equations I: Nonstiff Problems", Sec. II.4.
+//!     """
+//!     K[0] = f
+//!     for s, (a, c) in enumerate(zip(A, C)):
+//!         dy = np.dot(K[:s + 1].T, a) * h
+//!         K[s + 1] = fun(t + c * h, y + dy)
+//!
+//!     y_new = y + h * np.dot(K[:-1].T, B)
+//!     f_new = fun(t + h, y_new)
+//!
+//!     K[-1] = f_new
+//!     error = np.dot(K.T, E) * h
+//!
+//!     return y_new, f_new, error
+//! ```
+//!
+//! A direct translation to `ndarray` looks like this:
+//!
+//! ```
+//! #[macro_use]
+//! extern crate ndarray;
+//!
+//! use ndarray::prelude::*;
+//!
+//! fn rk_step<F>(
+//!     mut fun: F,
+//!     t: f64,
+//!     y: ArrayView1<f64>,
+//!     f: ArrayView1<f64>,
+//!     h: f64,
+//!     a: &[ArrayView1<f64>],
+//!     b: ArrayView1<f64>,
+//!     c: ArrayView1<f64>,
+//!     e: ArrayView1<f64>,
+//!     mut k: ArrayViewMut2<f64>,
+//! ) -> (Array1<f64>, Array1<f64>, Array1<f64>)
+//! where
+//!     F: FnMut(f64, ArrayView1<f64>) -> Array1<f64>,
+//! {
+//!     k.slice_mut(s![0, ..]).assign(&f);
+//!     for (s, (a, c)) in a.iter().zip(c).enumerate() {
+//!         let dy = k.slice(s![..s + 1, ..]).t().dot(a) * h;
+//!         k.slice_mut(s![s + 1, ..])
+//!             .assign(&(fun(t + c * h, (&y + &dy).view())));
+//!     }
+//!
+//!     let y_new = &y + &(h * k.slice::<Ix2>(s![..-1, ..]).t().dot(&b));
+//!     let f_new = fun(t + h, y_new.view());
+//!
+//!     k.slice_mut(s![-1, ..]).assign(&f_new);
+//!     let error = k.t().dot(&e) * h;
+//!
+//!     (y_new, f_new, error)
+//! }
+//! #
+//! # fn main() {}
+//! ```
+//!
+//! It's possible to improve the efficiency by doing the following:
+//!
+//! * Observe that `dy` is a temporary allocation. It's possible to allow the
+//!   add operation to take ownership of `dy` to eliminate an extra allocation
+//!   for the result of the addition. A similar situation occurs when computing
+//!   `y_new`. See the comments in the example below.
+//!
+//! * Require the `fun` closure to mutate an existing view instead of
+//!   allocating a new array for the result.
+//!
+//! * Don't return a newly allocated `f_new` array. If the caller wants this
+//!   information, they can get it from the last row of `k`.
+//!
+//! * Use [`c.mul_add(h, t)`][f64.mul_add()] instead of `t + c * h`. This is
+//!   faster and reduces the floating-point error. It might also be beneficial
+//!   to use [`.scaled_add()`][.scaled_add()] or a combination of
+//!   [`azip!()`][azip!] and [`.mul_add()`][f64.mul_add()] on the arrays in
+//!   some places, but that's not demonstrated in the example below.
+//!
+//! ```
+//! #[macro_use]
+//! extern crate ndarray;
+//!
+//! use ndarray::prelude::*;
+//!
+//! fn rk_step<F>(
+//!     mut fun: F,
+//!     t: f64,
+//!     y: ArrayView1<f64>,
+//!     f: ArrayView1<f64>,
+//!     h: f64,
+//!     a: &[ArrayView1<f64>],
+//!     b: ArrayView1<f64>,
+//!     c: ArrayView1<f64>,
+//!     e: ArrayView1<f64>,
+//!     mut k: ArrayViewMut2<f64>,
+//! ) -> (Array1<f64>, Array1<f64>)
+//! where
+//!     F: FnMut(f64, ArrayView1<f64>, ArrayViewMut1<f64>),
+//! {
+//!     k.slice_mut(s![0, ..]).assign(&f);
+//!     for (s, (a, c)) in a.iter().zip(c).enumerate() {
+//!         let dy = k.slice(s![..s + 1, ..]).t().dot(a) * h;
+//!         // Note that `dy` comes before `&y` in `dy + &y` in order to reuse the
+//!         // `dy` allocation. (The addition operator will take ownership of `dy`
+//!         // and assign the result to it instead of allocating a new array for the
+//!         // result.) In contrast, you could use `&y + &dy`, but that would perform
+//!         // an unnecessary memory allocation for the result, like NumPy does.
+//!         fun(c.mul_add(h, t), (dy + &y).view(), k.slice_mut(s![s + 1, ..]));
+//!     }
+//!     // Similar case here — moving `&y` to the right hand side allows the addition
+//!     // to reuse the allocated array on the left hand side.
+//!     let y_new = h * k.slice::<Ix2>(s![..-1, ..]).t().dot(&b) + &y;
+//!     // Mutate the last row of `k` in-place instead of allocating a new array.
+//!     fun(t + h, y_new.view(), k.slice_mut(s![-1, ..]));
+//!
+//!     let error = k.t().dot(&e) * h;
+//!
+//!     (y_new, error)
+//! }
+//! #
+//! # fn main() {}
+//! ```
+//!
+//! [f64.mul_add()]: https://doc.rust-lang.org/std/primitive.f64.html#method.mul_add
+//! [.scaled_add()]: ../../../struct.ArrayBase.html#method.scaled_add
+//! [azip!]: ../../../macro.azip.html
+//!
+//! ### SciPy license
+//!
+//! ```text
+//! Copyright (c) 2001, 2002 Enthought, Inc.
+//! All rights reserved.
+//!
+//! Copyright (c) 2003-2017 SciPy Developers.
+//! All rights reserved.
+//!
+//! Redistribution and use in source and binary forms, with or without
+//! modification, are permitted provided that the following conditions are met:
+//!
+//!   a. Redistributions of source code must retain the above copyright notice,
+//!      this list of conditions and the following disclaimer.
+//!   b. Redistributions in binary form must reproduce the above copyright
+//!      notice, this list of conditions and the following disclaimer in the
+//!      documentation and/or other materials provided with the distribution.
+//!   c. Neither the name of Enthought nor the names of the SciPy Developers
+//!      may be used to endorse or promote products derived from this software
+//!      without specific prior written permission.
+//!
+//!
+//! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+//! BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+//! OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+//! THE POSSIBILITY OF SUCH DAMAGE.
+//! ```

--- a/src/doc/ndarray_for_numpy_users/simple_math.rs
+++ b/src/doc/ndarray_for_numpy_users/simple_math.rs
@@ -1,0 +1,89 @@
+//! Example of simple math operations on 2-D arrays.
+//!
+//! <table>
+//!
+//! <tr>
+//! <th>
+//!
+//! NumPy
+//!
+//! </th>
+//! <th>
+//!
+//! `ndarray`
+//!
+//! </th>
+//! </tr>
+//! <tr>
+//! <td>
+//!
+//! ```python
+//! import numpy as np
+//!
+//!
+//!
+//!
+//!
+//! a = np.full((5, 4), 3.)
+//!
+//!
+//! a[::2, :] = 2.
+//!
+//!
+//! a[:, 1] = np.sin(a[:, 1]) + 1.
+//!
+//!
+//! a[a < 1.5] = 4.
+//!
+//!
+//! odd_sum = a[:, 1::2].sum()
+//!
+//!
+//! b = np.exp(np.arange(4))
+//!
+//!
+//! c = a + b
+//!
+//!
+//! d = c.T.dot(a)
+//! ```
+//!
+//! </td>
+//! <td>
+//!
+//! ```
+//! #[macro_use]
+//! extern crate ndarray;
+//!
+//! use ndarray::prelude::*;
+//!
+//! # fn main() {
+//! // Create a 5×4 array of threes.
+//! let mut a = Array2::<f64>::from_elem((5, 4), 3.);
+//!
+//! // Fill the even-index rows with twos.
+//! a.slice_mut(s![..;2, ..]).fill(2.);
+//!
+//! // Change column 1 to sin(x) + 1.
+//! a.column_mut(1).mapv_inplace(|x| x.sin() + 1.);
+//!
+//! // Change values less than 1.5 to 4.
+//! a.mapv_inplace(|x| if x < 1.5 { 4. } else { x });
+//!
+//! // Compute the scalar sum of the odd-index columns.
+//! let odd_sum = a.slice(s![.., 1..;2]).scalar_sum();
+//!
+//! // Create a 1-D array of exp(index).
+//! let b = Array::from_shape_fn(4, |i| (i as f64).exp());
+//!
+//! // Add b to a (broadcasting to rows).
+//! let c = a + &b;
+//!
+//! // Matrix product of c transpose with c.
+//! let d = c.t().dot(&c);
+//! # }
+//! ```
+//!
+//! </td>
+//! </tr>
+//! </table>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,15 @@
 //!     Uses ``blas-src`` for pluggable backend, which needs to be configured
 //!     separately.
 //!
+//! ## Documentation
+//!
+//! * The docs for [`ArrayBase`](struct.ArrayBase.html) provide an overview of
+//!   the *n*-dimensional array type. Other good pages to look at are the
+//!   documentation for the [`s![]`](macro.s.html) and
+//!   [`azip!()`](macro.azip.html) macros.
+//!
+//! * If you have experience with NumPy, you may also be interested in
+//!   [`ndarray_for_numpy_users`](doc/ndarray_for_numpy_users/index.html).
 
 #[cfg(feature = "serde-1")]
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ extern crate matrixmultiply;
 extern crate num_traits as libnum;
 extern crate num_complex;
 
+#[cfg(feature = "docs")]
+pub mod doc;
+
 use std::marker::PhantomData;
 use std::sync::Arc;
 


### PR DESCRIPTION
Motivated by @rcarson3 in #419, I put together an initial "`ndarray` for NumPy users" document ([rendered here](https://github.com/jturner314/rust-ndarray/blob/ndarray-for-numpy-users/ndarray-for-numpy-users.md)). It needs more stuff added (maybe some examples solving the same problems with NumPy and `ndarray`?), and I'm not convinced that a big table is the best way to organize things, but it's a start.

@rcarson3 What do you think so far?

Where's the best place to put this? Just host it on GitHub at `bluss/rust-ndarray` and link to it from the README and docs, or is there a good way to put it on its own page in the docs themselves?

Fixes #399 