### PR TITLE
Fix type inference for slicing in some cases

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -440,30 +440,30 @@ macro_rules! impl_slicenextdim_for_index_type {
                 PhantomData
             }
         }
-
-        impl<D1: Dimension> SliceNextDim<D1, D1::Larger> for Range<$index> {
-            fn next_dim(&self, _: PhantomData<D1>) -> PhantomData<D1::Larger> {
-                PhantomData
-            }
-        }
-
-        impl<D1: Dimension> SliceNextDim<D1, D1::Larger> for RangeFrom<$index> {
-            fn next_dim(&self, _: PhantomData<D1>) -> PhantomData<D1::Larger> {
-                PhantomData
-            }
-        }
-
-        impl<D1: Dimension> SliceNextDim<D1, D1::Larger> for RangeTo<$index> {
-            fn next_dim(&self, _: PhantomData<D1>) -> PhantomData<D1::Larger> {
-                PhantomData
-            }
-        }
     }
 }
 
 impl_slicenextdim_for_index_type!(isize);
 impl_slicenextdim_for_index_type!(usize);
 impl_slicenextdim_for_index_type!(i32);
+
+impl<D1: Dimension, T> SliceNextDim<D1, D1::Larger> for Range<T> {
+    fn next_dim(&self, _: PhantomData<D1>) -> PhantomData<D1::Larger> {
+        PhantomData
+    }
+}
+
+impl<D1: Dimension, T> SliceNextDim<D1, D1::Larger> for RangeFrom<T> {
+    fn next_dim(&self, _: PhantomData<D1>) -> PhantomData<D1::Larger> {
+        PhantomData
+    }
+}
+
+impl<D1: Dimension, T> SliceNextDim<D1, D1::Larger> for RangeTo<T> {
+    fn next_dim(&self, _: PhantomData<D1>) -> PhantomData<D1::Larger> {
+        PhantomData
+    }
+}
 
 impl<D1: Dimension> SliceNextDim<D1, D1::Larger> for RangeFull {
     fn next_dim(&self, _: PhantomData<D1>) -> PhantomData<D1::Larger> {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -82,6 +82,21 @@ fn test_slice()
     assert!(vi.iter().zip(A.iter()).all(|(a, b)| a == b));
 }
 
+/// Test that the compiler can infer a type for a sliced array from the
+/// arguments to `s![]`.
+///
+/// This test relies on the fact that `.dot()` is implemented for both
+/// `ArrayView1` and `ArrayView2`, so the compiler needs to determine which
+/// type is the correct result for the `.slice()` call.
+#[test]
+fn test_slice_infer()
+{
+    let a = array![1., 2.];
+    let b = array![[3., 4.], [5., 6.]];
+    b.slice(s![..-1, ..]).dot(&a);
+    // b.slice(s![0, ..]).dot(&a);
+}
+
 #[test]
 fn test_slice_with_many_dim() {
     let mut A = RcArray::<usize, _>::zeros(&[3, 1, 4, 1, 3, 2, 1][..]);


### PR DESCRIPTION
In some cases, the compiler does not infer a dimension type for a sliced array. (It says "multiple applicable items in scope" when calling `.dot()` on the sliced array.) See the `test_slice_infer` test in this PR.

A partial fix is to implement `SliceNextDim` for more `Range*` types. I'm not quite sure why this works, and inference is still broken for integers that aren't part of ranges (the commented-out line in `test_slice_infer`), but it's an improvement.

It's worth noting that I also tried implementing `SliceNextDim` for `Range*<u8>`, `Range*<u16>`, … (all primitive integer types) instead of `Range*<T>` where `T: PrimInt`, but that didn't fix the issue.

I've tried fixing inference for integers that aren't part of ranges, but I haven't had any success. Some of the things I've tried:

* Implementing `SliceNextDim` for `u8`, `u16`, … (all primitive integer types), but that didn't fix the issue.
* Changing the `D2` generic type parameter in `SliceNextDim<D1, D2>` to an associated type. I think that's a better design anyway (and I'll create a PR for this later since it's a breaking change), but it didn't fix this issue.
* Adding another trait `SliceNextDimInner<D>` and then implementing `SliceNextDim` for `T: SliceNextDimInner<D>`, but that didn't fix the issue.

Does anyone have suggestions for fixing inference with integers that aren't part of ranges?